### PR TITLE
Add duplicating_network flag.

### DIFF
--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -159,6 +159,7 @@ fn system(client_count: u8) -> System<RegisterActor<char, Paxos>> {
         actors,
         init_network: Vec::with_capacity(20),
         lossy_network: LossyNetwork::No,
+        duplicating_network: DuplicatingNetwork::Yes,
     }
 }
 

--- a/examples/wor.rs
+++ b/examples/wor.rs
@@ -55,6 +55,7 @@ fn system(servers: Vec<WriteOnce>, client_count: u8)
         actors,
         init_network: Vec::new(),
         lossy_network: LossyNetwork::Yes, // for some extra states
+        duplicating_network: DuplicatingNetwork::Yes,
     }
 }
 


### PR DESCRIPTION
Hi! Thanks so much for building this library, it's great!

As a first contribution, here's a change that lets users prune the portion of search space that consists of duplicate messages -- some systems have trivially idempotent messages, where exploring all the extra delivery schedules is just a waste of model-checking time.