### PR TITLE
Add support for "eventually" (at least acyclic liveness) properties.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ regex = "1.3.1"
 serde = { version = "1.0.104", features = ["rc"] }
 serde_derive = "1.0.104"
 serde_json = "1.0.44"
+id-set = "0.2.2"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/src/actor/system.rs
+++ b/src/actor/system.rs
@@ -290,11 +290,13 @@ mod test {
                 PingPong::PongActor,
             ],
             init_network: Vec::new(),
-            lossy_network: LossyNetwork::Yes,
-            duplicating_network: DuplicatingNetwork::Yes,
+            lossy_network: LossyNetwork::No,
+            duplicating_network: DuplicatingNetwork::No,
         }.model(5).checker();
         assert_eq!(checker.check(10_000).counterexample("delta within 1"), None);
+        assert_eq!(checker.check(10_000).counterexample("max_nat"), None);
+        assert_ne!(checker.check(10_000).counterexample("max_nat_plus_one"), None);
         assert_eq!(checker.is_done(), true);
-        assert_eq!(checker.generated_count(), 4_094);
+        assert_eq!(checker.generated_count(), 11);
     }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -152,13 +152,22 @@ pub mod ping_pong {
 
     impl System<PingPong> {
         pub fn model(self, max_nat: u32) -> Model<'static, Self> {
+            let max_nat_0 = max_nat;
+            let max_nat_1 = max_nat + 1;
             Model {
                 state_machine: self,
-                properties: vec![Property::always("delta within 1", |_sys, state: &SystemState<PingPong>| {
-                    let max = state.actor_states.iter().map(|s| s.0).max().unwrap();
-                    let min = state.actor_states.iter().map(|s| s.0).min().unwrap();
-                    max - min <= 1
-                })],
+                properties: vec![
+                    Property::always("delta within 1", |_sys, state: &SystemState<PingPong>| {
+                        let max = state.actor_states.iter().map(|s| s.0).max().unwrap();
+                        let min = state.actor_states.iter().map(|s| s.0).min().unwrap();
+                        max - min <= 1
+                    }),
+                    Property::eventually("max_nat", move |_sys, state: &SystemState<PingPong>| {
+                        state.actor_states.iter().any(|s| s.0 == max_nat_0)
+                    }),
+                    Property::eventually("max_nat_plus_one", move |_sys, state: &SystemState<PingPong>| {
+                        state.actor_states.iter().any(|s| s.0 == max_nat_1)
+                    })],
                 boundary: Some(Box::new( move |_sys, state| {
                     state.actor_states.iter().all(|s| s.0 <= max_nat)
                 })),


### PR DESCRIPTION
This PR adds a simple form of liveness-proerty checking -- "eventually" properties. They're implemented by assigning a bit-number to each such property and propagating a compact bitset (`IdSet` from the id-set crate) representing properties not-yet-established on a given path, along with the state, in the queue of states. Any property still not-yet-established when we arrive at a terminal state is marked as a counterexample discovery, as with "always" properties, and reported the same way.

These properties suffer from two possible false negatives:

  - Cyclic paths are not disambiguated from DAG joins, so neither is considered terminal. If an eventually property is not met by the cycle-closing edge of a cyclic path, it is forgotten.
  - DAG joins with different sets of liveness properties at the join point are not differentiated. If an eventually property was met on the first visit through a state but not on the second visit that joins it, it is not reported.

In theory both of these could be converted to a false _positive_ by considering revisited states as terminal. I'd be open to the argument that that's more-useful / more-correct. Not sure what's more annoying to users in practice; the code is anyways factored in such a way that you'd only have to add one more call to `note_terminal_state` to switch to that way, if you prefer.