### PR TITLE
Upstreaming changes for vectorpaxos

### DIFF
--- a/examples/2pc.rs
+++ b/examples/2pc.rs
@@ -172,7 +172,7 @@ fn main() -> Result<(), pico_args::Error> {
                         msgs: self.msgs.iter().map(|m| {
                             match m {
                                 Message::Prepared { rm } =>
-                                    Message::Prepared { rm: plan.rewrite(*rm) },
+                                    Message::Prepared { rm: plan.rewrite(rm) },
                                 Message::Commit => Message::Commit,
                                 Message::Abort => Message::Abort,
                             }
@@ -181,7 +181,7 @@ fn main() -> Result<(), pico_args::Error> {
                 }
             }
             impl<T> Rewrite<T> for RmState {
-                fn rewrite(&self, _: &RewritePlan<T>) -> Self {
+                fn rewrite<S>(&self, _: &RewritePlan<T,S>) -> Self {
                     self.clone()
                 }
             }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -97,6 +97,7 @@ pub use model::*;
 pub use model_state::*;
 pub mod ordered_reliable_link;
 pub mod register;
+pub mod write_once_register;
 pub use spawn::*;
 
 /// Uniquely identifies an [`Actor`]. Encodes the socket address for spawned

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -213,7 +213,7 @@ where A: Actor,
         let mut init_sys_state = ActorModelState {
             actor_states: Vec::with_capacity(self.actors.len()),
             history: self.init_history.clone(),
-            is_timer_set: Vec::new(),
+            is_timer_set: vec![false; self.actors.len()],
             network: Network::with_hasher(
                 crate::stable::build_hasher()), // for consistent discoveries
         };
@@ -528,10 +528,11 @@ mod test {
 
         // helper to make the test more concise
         let states_and_network = |states: Vec<u32>, envelopes: Vec<Envelope<_>>| {
+            let is_timer_set = vec![false; states.len()];
             ActorModelState {
                 actor_states: states.into_iter().map(|s| Arc::new(s)).collect::<Vec<_>>(),
                 network: Network::from_iter(envelopes),
-                is_timer_set: Vec::new(),
+                is_timer_set,
                 history: (0_u32, 0_u32), // constant as `maintains_history: false`
             }
         };

--- a/src/actor/model_state.rs
+++ b/src/actor/model_state.rs
@@ -207,7 +207,7 @@ mod test {
     #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     struct ActorState { acks: Vec<Id> }
     impl Rewrite<Id> for ActorState {
-        fn rewrite(&self, plan: &RewritePlan<Id>) -> Self {
+        fn rewrite<S>(&self, plan: &RewritePlan<Id, S>) -> Self {
             Self { acks: self.acks.rewrite(plan) }
         }
     }
@@ -215,7 +215,7 @@ mod test {
     #[derive(Debug, PartialEq)]
     struct History { send_sequence: Vec<Id> }
     impl Rewrite<Id> for History {
-        fn rewrite(&self, plan: &RewritePlan<Id>) -> Self {
+        fn rewrite<S>(&self, plan: &RewritePlan<Id, S>) -> Self {
             Self { send_sequence: self.send_sequence.rewrite(plan) }
         }
     }

--- a/src/actor/write_once_register.rs
+++ b/src/actor/write_once_register.rs
@@ -1,0 +1,301 @@
+//! Defines an interface for write-once-register-like actors (via [`WORegisterMsg`]) and also provides
+//! [`WORegisterActor`] for model checking.
+
+#[cfg(doc)]
+use crate::actor::ActorModel;
+use crate::actor::{Actor, Envelope, Id, Out};
+use crate::semantics::ConsistencyTester;
+use crate::semantics::write_once_register::{WORegister, WORegisterOp, WORegisterRet};
+use crate::checker::{Rewrite, RewritePlan};
+use std::borrow::Cow;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+/// Defines an interface for a register-like actor.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum WORegisterMsg<RequestId, Value, InternalMsg> {
+    /// A message specific to the register system's internal protocol.
+    Internal(InternalMsg),
+
+    /// Indicates that a value should be written.
+    Put(RequestId, Value),
+    /// Indicates that a value should be retrieved.
+    Get(RequestId),
+
+    /// Indicates a successful `Put`. Analogous to an HTTP 2XX.
+    PutOk(RequestId),
+    /// Indicates an unsuccessful `Put`.
+    PutFail(RequestId),
+    /// Indicates a successful `Get`. Analogous to an HTTP 2XX.
+    GetOk(RequestId, Value),
+}
+use WORegisterMsg::*;
+
+impl<RequestId, Value, InternalMsg> WORegisterMsg<RequestId, Value, InternalMsg> {
+    /// This is a helper for configuring an [`ActorModel`] parameterized by a [`ConsistencyTester`]
+    /// for its history. Simply pass this method to [`ActorModel::record_msg_out`]. Records
+    /// [`WORegisterOp::Read`] upon [`WORegisterMsg::Get`] and [`WORegisterOp::Write`] upon
+    /// [`WORegisterMsg::Put`].
+    pub fn record_invocations<C, H>(
+        _cfg: &C,
+        history: &H,
+        env: Envelope<&WORegisterMsg<RequestId, Value, InternalMsg>>)
+        -> Option<H>
+    where H: Clone + ConsistencyTester<Id, WORegister<Value>>,
+          Value: Clone + Debug + PartialEq,
+    {
+        // Currently throws away useful information about invalid histories. Ideally
+        // checking would continue, but the property would be labeled with an error.
+        if let Get(_) = env.msg {
+            let mut history = history.clone();
+            let _ = history.on_invoke(env.src, WORegisterOp::Read);
+            Some(history)
+        } else if let Put(_req_id, value) = env.msg {
+            let mut history = history.clone();
+            let _ = history.on_invoke(env.src, WORegisterOp::Write(value.clone()));
+            Some(history)
+        } else {
+            None
+        }
+    }
+
+    /// This is a helper for configuring an [`ActorModel`] parameterized by a [`ConsistencyTester`]
+    /// for its history. Simply pass this method to [`ActorModel::record_msg_in`]. Records
+    /// [`WORegisterRet::ReadOk`] upon [`WORegisterMsg::GetOk`] and [`WORegisterRet::WriteOk`] upon
+    /// [`WORegisterMsg::PutOk`].
+    pub fn record_returns<C, H>(
+        _cfg: &C,
+        history: &H,
+        env: Envelope<&WORegisterMsg<RequestId, Value, InternalMsg>>)
+        -> Option<H>
+    where H: Clone + ConsistencyTester<Id, WORegister<Value>>,
+          Value: Clone + Debug + PartialEq,
+    {
+        // Currently throws away useful information about invalid histories. Ideally
+        // checking would continue, but the property would be labeled with an error.
+        match env.msg {
+            GetOk(_, v) => {
+                let mut history = history.clone();
+                let _ = history.on_return(env.dst, WORegisterRet::ReadOk(Some(v.clone())));
+                Some(history)
+            }
+            PutOk(_) => {
+                let mut history = history.clone();
+                let _ = history.on_return(env.dst, WORegisterRet::WriteOk);
+                Some(history)
+            }
+            PutFail(_) => {
+                let mut history = history.clone();
+                let _ = history.on_return(env.dst, WORegisterRet::WriteFail);
+                Some(history)
+            }
+            _ => None
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WORegisterActor<ServerActor> {
+    /// A client that [`WORegisterMsg::Put`]s a message and upon receving a
+    /// corresponding [`WORegisterMsg::PutOk`] follows up with a
+    /// [`WORegisterMsg::Get`].
+    Client {
+        put_count: usize,
+        server_count: usize,
+    },
+    /// A server actor being validated.
+    Server(ServerActor),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(serde::Serialize)]
+pub enum WORegisterActorState<ServerState, RequestId> {
+    /// A client that sends a sequence of [`WORegisterMsg::Put`] messages before sending a
+    /// [`WORegisterMsg::Get`].
+    Client {
+        awaiting: Option<RequestId>,
+        op_count: u64,
+    },
+    /// Wraps the state of a server actor.
+    Server(ServerState),
+}
+
+// This implementation assumes the servers are at the beginning of the list of
+// actors in the system under test so that an arbitrary server destination ID
+// can be derived from `(client_id.0 + k) % server_count` for any `k`.
+impl<ServerActor, InternalMsg> Actor for WORegisterActor<ServerActor>
+where
+    ServerActor: Actor<Msg = WORegisterMsg<u64, char, InternalMsg>>,
+    InternalMsg: Clone + Debug + Eq + Hash,
+{
+    type Msg = WORegisterMsg<u64, char, InternalMsg>;
+    type State = WORegisterActorState<ServerActor::State, u64>;
+
+    #[allow(clippy::identity_op)]
+    fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {
+        match self {
+            WORegisterActor::Client { put_count, server_count } => {
+                let server_count = *server_count as u64;
+
+                let index = id.0;
+                if index < server_count {
+                    panic!("WORegisterActor clients must be added to the model after servers.");
+                }
+
+                if *put_count == 0 {
+                    WORegisterActorState::Client {
+                        awaiting: None,
+                        op_count: 0,
+                    }
+                } else {
+                    let unique_request_id = 1 * index as u64; // next will be 2 * index
+                    let value = (b'A' + (index - server_count) as u8) as char;
+                    o.send(
+                        Id((index + 0) % server_count),
+                        Put(unique_request_id, value));
+                    WORegisterActorState::Client {
+                        awaiting: Some(unique_request_id),
+                        op_count: 1,
+                    }
+                }
+            }
+            WORegisterActor::Server(server_actor) => {
+                let mut server_out = Out::new();
+                let state = WORegisterActorState::Server(server_actor.on_start(id, &mut server_out));
+                o.append(&mut server_out);
+                state
+            }
+        }
+    }
+
+    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, o: &mut Out<Self>) {
+        use WORegisterActor as A;
+        use WORegisterActorState as S;
+        match (self, &**state) {
+            (
+                A::Client { .. },
+                S::Client { .. }
+            ) => {},
+            (
+                A::Server(server_actor),
+                S::Server(server_state)
+            ) => {
+                let mut server_state = Cow::Borrowed(server_state);
+                let mut server_out = Out::new();
+                server_actor.on_timeout(id, &mut server_state, &mut server_out);
+                if let Cow::Owned(server_state) = server_state {
+                    *state = Cow::Owned(WORegisterActorState::Server(server_state))
+                }
+                o.append(&mut server_out);
+            }
+            _ => {}
+        }
+    }
+
+    fn on_msg(&self, id: Id, state: &mut Cow<Self::State>, src: Id, msg: Self::Msg, o: &mut Out<Self>) {
+        use WORegisterActor as A;
+        use WORegisterActorState as S;
+
+        match (self, &**state) {
+            (
+                A::Client { put_count, server_count },
+                S::Client { awaiting: Some(awaiting), op_count },
+            ) => {
+                let server_count = *server_count as u64;
+                match msg {
+                    WORegisterMsg::PutOk(request_id) if &request_id == awaiting => {
+                        let index = id.0;
+                        let unique_request_id = ((op_count + 1) * index) as u64;
+                        if *op_count < *put_count as u64 {
+                            let value = (b'Z' - (index - server_count) as u8) as char;
+                            o.send(
+                                Id((index + op_count) % server_count),
+                                Put(unique_request_id, value));
+                        } else {
+                            o.send(
+                                Id((index + op_count) % server_count),
+                                Get(unique_request_id));
+                        }
+                        *state = Cow::Owned(WORegisterActorState::Client {
+                            awaiting: Some(unique_request_id),
+                            op_count: op_count + 1,
+                        });
+                    }
+                    WORegisterMsg::PutFail(request_id) if &request_id == awaiting => {
+                        let index = id.0;
+                        let unique_request_id = ((op_count + 1) * index) as u64;
+                        if *op_count < *put_count as u64 {
+                            let value = (b'Z' - (index - server_count) as u8) as char;
+                            o.send(
+                                Id((index + op_count) % server_count),
+                                Put(unique_request_id, value));
+                        } else {
+                            o.send(
+                                Id((index + op_count) % server_count),
+                                Get(unique_request_id));
+                        }
+                        *state = Cow::Owned(WORegisterActorState::Client {
+                            awaiting: Some(unique_request_id),
+                            op_count: op_count + 1,
+                        });
+                    }
+                    WORegisterMsg::GetOk(request_id, _value) if &request_id == awaiting => {
+                        *state = Cow::Owned(WORegisterActorState::Client {
+                            awaiting: None,
+                            op_count: op_count + 1,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            (
+                A::Server(server_actor),
+                S::Server(server_state),
+            ) => {
+                let mut server_state = Cow::Borrowed(server_state);
+                let mut server_out = Out::new();
+                server_actor.on_msg(id, &mut server_state, src, msg, &mut server_out);
+                if let Cow::Owned(server_state) = server_state {
+                    *state = Cow::Owned(WORegisterActorState::Server(server_state))
+                }
+                o.append(&mut server_out);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<R, ServerState, RequestId> Rewrite<R> for WORegisterActorState<ServerState, RequestId>
+where ServerState : Rewrite<R> + Clone,
+      RequestId : Clone,
+{
+    fn rewrite<S>(&self, plan: &RewritePlan<R,S>) -> Self {
+        match self {
+            WORegisterActorState::Client{..} => { (*self).clone() }
+            WORegisterActorState::Server(server_state) => { 
+                WORegisterActorState::Server(server_state.rewrite(plan)) 
+            }
+        }
+   }
+}
+
+impl<R, RequestId, Value, InternalMsg> Rewrite<R> for WORegisterMsg<RequestId, Value, InternalMsg>
+where InternalMsg : Rewrite<R>,
+      RequestId : Clone,
+      Value : Rewrite<R>,
+{
+    fn rewrite<S>(&self, plan: &RewritePlan<R,S>) -> Self {
+        match self {
+            Internal(msg) => Internal(msg.rewrite(plan)),
+            Put(rid, v) => Put(rid.clone(), v.rewrite(plan)),
+            Get(rid) => Get(rid.clone()),
+
+            PutOk(rid) => PutOk(rid.clone()),
+            PutFail(rid) => PutFail(rid.clone()),
+            GetOk(rid, v) => GetOk(rid.clone(), v.rewrite(plan))
+        }
+   }
+}
+
+

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -457,12 +457,12 @@ mod test {
         }
         impl Representative for SysState {
             fn representative(&self) -> Self {
-                let plan = RewritePlan::<Id>::from_values_to_sort(&self.0);
+                let plan = RewritePlan::from_values_to_sort(&self.0);
                 SysState(plan.reindex(&self.0))
             }
         }
         impl Rewrite<Id> for ProcState {
-            fn rewrite(&self, _: &RewritePlan<Id>) -> Self {
+            fn rewrite<S>(&self, _: &RewritePlan<Id, S>) -> Self {
                 self.clone()
             }
         }

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -309,7 +309,7 @@ mod test {
                     state: Some(ActorModelState {
                         actor_states: vec![Arc::new(0), Arc::new(0)],
                         history: (0, 1),
-                        is_timer_set: vec![],
+                        is_timer_set: vec![false,false],
                         network: Network::from_iter(vec![
                             Envelope { src: Id::from(0), dst: Id::from(1), msg: Ping(0) },
                         ]),
@@ -324,7 +324,7 @@ mod test {
                 let fp = fingerprint(&ActorModelState::<PingPongActor, PingPongHistory> {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
-                    is_timer_set: vec![],
+                    is_timer_set: vec![false,false],
                     network: Network::from_iter(vec![
                         Envelope { src: Id::from(0), dst: Id::from(1), msg: Ping(0) },
                     ]),
@@ -342,7 +342,7 @@ mod test {
                 state: Some(ActorModelState {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
-                    is_timer_set: vec![],
+                    is_timer_set: vec![false,false],
                     network: Network::new(),
                 }),
                 svg: Some("<svg version='1.1' baseProfile='full' width='500' height='60' viewbox='-20 -20 520 80' xmlns='http://www.w3.org/2000/svg'><defs><marker class='svg-event-shape' id='arrow' markerWidth='12' markerHeight='10' refX='12' refY='5' orient='auto'><polygon points='0 0, 12 5, 0 10' /></marker></defs><line x1='0' y1='0' x2='0' y2='60' class='svg-actor-timeline' />\n<text x='0' y='0' class='svg-actor-label'>0</text>\n<line x1='100' y1='0' x2='100' y2='60' class='svg-actor-timeline' />\n<text x='100' y='0' class='svg-actor-label'>1</text>\n</svg>\n".to_string()),
@@ -358,7 +358,7 @@ mod test {
                         Arc::new(1),
                     ],
                     history: (1, 2),
-                    is_timer_set: vec![],
+                    is_timer_set: vec![false,false],
                     network: Network::from_iter(vec![
                         Envelope { src: Id::from(1), dst: Id::from(0), msg: Pong(0) },
                     ]),

--- a/src/checker/representative.rs
+++ b/src/checker/representative.rs
@@ -31,7 +31,7 @@
 /// }
 /// impl Representative for SystemState {
 ///     fn representative(&self) -> Self {
-///         let plan = RewritePlan::new(&self.process_states);
+///         let plan = (&self.process_states).into();
 ///         Self {
 ///             process_states: self.process_states.rewrite(&plan),
 ///             time_slice_sequence: self.time_slice_sequence.rewrite(&plan),
@@ -49,7 +49,7 @@
 ///     // ... etc ...
 /// }
 /// impl Rewrite<Pid> for ProcessState {
-///     fn rewrite(&self, plan: &RewritePlan<Pid>) -> Self {
+///     fn rewrite<S>(&self, plan: &RewritePlan<Pid,S>) -> Self {
 ///         Self {
 ///             program_counter: self.program_counter.rewrite(plan), // no-op (cannot contain `Pid`)
 ///             parent: self.parent.rewrite(plan),

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -52,6 +52,7 @@ mod sequential_consistency;
 
 pub use consistency_tester::ConsistencyTester;
 pub mod register;
+pub mod write_once_register;
 pub use linearizability::LinearizabilityTester;
 pub use sequential_consistency::SequentialConsistencyTester;
 pub mod vec;

--- a/src/semantics/write_once_register.rs
+++ b/src/semantics/write_once_register.rs
@@ -1,0 +1,109 @@
+//! Implements [`SequentialSpec`] for [`WriteOnceRegister`] operational semantics.
+
+use std::fmt::Debug;
+use super::SequentialSpec;
+
+/// A simple register used to define reference operational semantics via
+/// [`SequentialSpec`].
+#[derive(Clone, Default, Debug, Hash, PartialEq)]
+#[derive(serde::Serialize)]
+pub struct WORegister<T>(pub Option<T>);
+
+/// An operation that can be invoked upon a [`WORegister`], resulting in a
+/// [`WORegisterRet`]
+#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(serde::Serialize)]
+pub enum WORegisterOp<T> { Write(T), Read }
+
+/// A return value for a [`WORegisterOp`] invoked upon a [`WORegister`].
+#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(serde::Serialize)]
+pub enum WORegisterRet<T> { WriteOk, WriteFail, ReadOk(Option<T>) }
+
+impl<T: Clone + Debug + PartialEq> SequentialSpec for WORegister<T> {
+    type Op = WORegisterOp<T>;
+    type Ret = WORegisterRet<T>;
+    fn invoke(&mut self, op: &Self::Op) -> Self::Ret {
+        match (op, &self.0) {
+            (WORegisterOp::Write(v), None) => {
+                self.0 = Some(v.clone());
+                WORegisterRet::WriteOk
+            }
+            // If something has already been written succeed if equal
+            (WORegisterOp::Write(v), Some(vp)) if *v == *vp => {
+                self.0 = Some(v.clone());
+                WORegisterRet::WriteOk
+            }
+            (WORegisterOp::Write(_), Some(_)) => {
+                WORegisterRet::WriteFail
+            }
+            (WORegisterOp::Read, _) => WORegisterRet::ReadOk(self.0.clone()),
+        }
+    }
+    fn is_valid_step(&mut self, op: &Self::Op, ret: &Self::Ret) -> bool {
+        // Override to avoid unnecessary `clone` on `Read`.
+        match (op, ret, &self.0) {
+            (WORegisterOp::Write(v), WORegisterRet::WriteOk, None) => {
+                self.0 = Some(v.clone());
+                true
+            }
+            (WORegisterOp::Write(v), WORegisterRet::WriteOk, Some(vp)) if *v == *vp => {
+                true
+            }
+            (WORegisterOp::Write(v), WORegisterRet::WriteFail, Some(vp)) if *v != *vp => {
+                true
+            }
+            (WORegisterOp::Read, WORegisterRet::ReadOk(v), _) => {
+                &self.0 == v
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn models_expected_semantics() {
+        let mut r = WORegister(None);
+        assert_eq!(r.invoke(&WORegisterOp::Write('A')), WORegisterRet::WriteOk);
+        assert_eq!(r.invoke(&WORegisterOp::Read),       WORegisterRet::ReadOk(Some('A')));
+        assert_eq!(r.invoke(&WORegisterOp::Write('B')), WORegisterRet::WriteFail);
+        assert_eq!(r.invoke(&WORegisterOp::Read),       WORegisterRet::ReadOk(Some('A')));
+    }
+
+    #[test]
+    fn accepts_valid_histories() {
+        let none_char : Option<char> = None;
+        assert!(WORegister(none_char).is_valid_history(vec![]));
+        assert!(WORegister(none_char).is_valid_history(vec![
+            (WORegisterOp::Read,       WORegisterRet::ReadOk(None)),
+            (WORegisterOp::Write('A'), WORegisterRet::WriteOk),
+            (WORegisterOp::Read,       WORegisterRet::ReadOk(Some('A'))),
+            (WORegisterOp::Write('B'), WORegisterRet::WriteFail),
+            (WORegisterOp::Read,       WORegisterRet::ReadOk(Some('A'))),
+            (WORegisterOp::Write('C'), WORegisterRet::WriteFail),
+            (WORegisterOp::Read,       WORegisterRet::ReadOk(Some('A'))),
+        ]));
+    }
+
+    #[test]
+    fn rejects_invalid_histories() {
+        let none_char : Option<char> = None;
+        assert!(!WORegister(Some('A')).is_valid_history(vec![
+            (WORegisterOp::Read,       WORegisterRet::ReadOk(Some('A'))),
+            (WORegisterOp::Write('B'), WORegisterRet::WriteOk),
+        ]));
+        assert!(!WORegister(none_char).is_valid_history(vec![
+            (WORegisterOp::Read,       WORegisterRet::ReadOk(Some('A'))),
+            (WORegisterOp::Write('A'), WORegisterRet::WriteOk),
+        ]));
+        assert!(!WORegister(none_char).is_valid_history(vec![
+            (WORegisterOp::Read,       WORegisterRet::ReadOk(None)),
+            (WORegisterOp::Write('A'), WORegisterRet::WriteOk),
+            (WORegisterOp::Write('B'), WORegisterRet::WriteOk),
+        ]));
+    }
+}

--- a/src/util/densenatmap.rs
+++ b/src/util/densenatmap.rs
@@ -205,7 +205,7 @@ where K: From<usize> + Rewrite<R>,
       usize: From<K>,
 {
     #[inline(always)]
-    fn rewrite(&self, plan: &RewritePlan<R>) -> Self {
+    fn rewrite<S>(&self, plan: &RewritePlan<R, S>) -> Self {
         // FIXME: simply reindexing the keys (while still rewriting the values) would be more
         //        efficient, but we need to vary behavior based on the key type (i.e. for
         //        `DenseNatMap<R, _>`, `Rewrite<R>` would reindex, while `Rewrite<!R>` would not).
@@ -264,15 +264,15 @@ mod test {
             fn from(input: Id2) -> Self { input.0 }
         }
         impl Rewrite<Id2> for Id2 {
-            fn rewrite(&self, plan: &RewritePlan<Id2>) -> Self {
-                plan.rewrite(*self)
+            fn rewrite<S>(&self, plan: &RewritePlan<Id2, S>) -> Self {
+                plan.rewrite(self)
             }
         }
         impl Rewrite<Id2> for Id {
-            fn rewrite(&self, _: &RewritePlan<Id2>) -> Self { *self }
+            fn rewrite<S>(&self, _: &RewritePlan<Id2, S>) -> Self { *self }
         }
         impl Rewrite<Id> for Id2 {
-            fn rewrite(&self, _: &RewritePlan<Id>) -> Self { *self }
+            fn rewrite<S>(&self, _: &RewritePlan<Id, S>) -> Self { *self }
         }
 
         // Now we simulate the fields of a data structure that needs to be rewritten. Most "fields"
@@ -284,7 +284,7 @@ mod test {
         let f5 = BTreeMap::from_iter([(Id::from(0), '!')]);
 
         // Rewriting based on `Id` symmetry importantly does *not* reindex the third field.
-        let plan = RewritePlan::new(&f1);
+        let plan = RewritePlan::from(&f1);
         assert_eq!(
             f1.rewrite(&plan),
             DenseNatMap::from_iter(['A', 'B', 'C', 'D']));
@@ -302,7 +302,7 @@ mod test {
             BTreeMap::from_iter([(Id::from(1), '!')]));
 
         // Rewriting based on `Id2` on the other hand impacts *only* the third field.
-        let plan = RewritePlan::new(&f3);
+        let plan = RewritePlan::from(&f3);
         assert_eq!(
             f1.rewrite(&plan),
             DenseNatMap::from_iter(['B', 'C', 'A', 'D'])); // *not* reindexed


### PR DESCRIPTION
This PR adds the required functionality to implement [VectorPaxos](https://github.com/cjen1/stateright/tree/vectorpaxos).

It makes several changes to the codebase:
- RewritePlan uses a closure
  - Previously the rewrite plan only allowed for strict reindexing of types which implement `From<usize>`
  - This changes it to carry some state which allows it to apply to more types, for example [ballots in VectorPaxos](https://github.com/Cjen1/stateright/blob/353312acd9808ce18365d6d119da7792bdfc3fa1/examples/vectorpaxos.rs#L28).
- Initialise timers to false
  - Previously timers were initialised as an empty vec
  - This meant that they could not be reindexed during the symmetry function.
- Add write-once-registers
  - This PR also adds a write-once-register implementation
  - This is the semantics provided by single-shot paxos and thus to test linearisability over them requires these semantics

Finally this adds one bug fix. Actors implementing the RegisterActor would not call their timeout function. This is due to no implementation in the RegisterActor resulting in it calling the default method which does not call the implementation's timeout method.