### PR TITLE
Add a sentence in the spawn help for using 'tcpdump -D`

### DIFF
--- a/examples/linearizable-register.rs
+++ b/examples/linearizable-register.rs
@@ -329,7 +329,10 @@ fn main() -> Result<(), pico_args::Error> {
             let port = 3000;
 
             println!("  A server that implements a linearizable register.");
-            println!("  You can interact with the server using netcat. Example:");
+            println!("  You can monitor and interact using tcpdump and netcat.");
+            println!("  Use `tcpdump -D` if you see error `lo0: No such device exists`.");
+            println!("Examples:");
+            println!("$ sudo tcpdump -i lo0 -s 0 -nnX");
             println!("$ nc -u localhost {}", port);
             println!("{}", serde_json::to_string(&RegisterMsg::Put::<RequestId, Value, ()>(1, 'X')).unwrap());
             println!("{}", serde_json::to_string(&RegisterMsg::Get::<RequestId, Value, ()>(2)).unwrap());

--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -359,7 +359,9 @@ fn main() -> Result<(), pico_args::Error> {
             let port = 3000;
 
             println!("  A set of servers that implement Single Decree Paxos.");
-            println!("  You can monitor and interact using tcpdump and netcat. Examples:");
+            println!("  You can monitor and interact using tcpdump and netcat.");
+            println!("  Use `tcpdump -D` if you see error `lo0: No such device exists`.");
+            println!("Examples:");
             println!("$ sudo tcpdump -i lo0 -s 0 -nnX");
             println!("$ nc -u localhost {}", port);
             println!("{}", serde_json::to_string(&RegisterMsg::Put::<RequestId, Value, ()>(1, 'X')).unwrap());

--- a/examples/single-copy-register.rs
+++ b/examples/single-copy-register.rs
@@ -169,7 +169,10 @@ fn main() -> Result<(), pico_args::Error> {
             let port = 3000;
 
             println!("  A server that implements a single-copy register.");
-            println!("  You can interact with the server using netcat. Example:");
+            println!("  You can monitor and interact using tcpdump and netcat.");
+            println!("  Use `tcpdump -D` if you see error `lo0: No such device exists`.");
+            println!("Examples:");
+            println!("$ sudo tcpdump -i lo0 -s 0 -nnX");
             println!("$ nc -u localhost {}", port);
             println!("{}", serde_json::to_string(&RegisterMsg::Put::<RequestId, Value, ()>(1, 'X')).unwrap());
             println!("{}", serde_json::to_string(&RegisterMsg::Get::<RequestId, Value, ()>(2)).unwrap());


### PR DESCRIPTION
The `-i lo0` parameter referrers to the device/interface that tcpdump will listen on
and not all systems use `lo0` to refer to the loop back interface. Executing `tcpdump -D`
will display a list of devices available on the system and the user can find the current
loop back device:

For instance on my computer device 3, `lo`, is the loop back device:

 $ tcpdump -D
 1.wlp170s0 [Up, Running, Wireless, Associated]
 2.any (Pseudo-device that captures on all interfaces) [Up, Running]
 3.lo [Up, Running, Loopback]
 4.bluetooth0 (Bluetooth adapter number 0) [Wireless, Association status unknown]
 5.bluetooth-monitor (Bluetooth Linux Monitor) [Wireless]
 6.nflog (Linux netfilter log (NFLOG) interface) [none]
 7.nfqueue (Linux netfilter queue (NFQUEUE) interface) [none]
 8.dbus-system (D-Bus system bus) [none]
 9.dbus-session (D-Bus session bus) [none]