### PR TITLE
Allow custom reporting

### DIFF
--- a/examples/2pc.rs
+++ b/examples/2pc.rs
@@ -3,6 +3,7 @@
 //! by Jim Gray and Leslie Lamport.
 
 use stateright::{Checker, Model, Property, Representative, Rewrite, RewritePlan};
+use stateright::report::WriteReporter;
 use std::collections::BTreeSet;
 use std::hash::Hash;
 use std::ops::Range;
@@ -151,7 +152,7 @@ fn main() -> Result<(), pico_args::Error> {
             println!("Checking two phase commit with {} resource managers.", rm_count);
             TwoPhaseSys { rms: 0..rm_count }.checker()
                 .threads(num_cpus::get()).spawn_dfs()
-                .report(&mut std::io::stdout());
+                .report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("check-sym") => {
             let rm_count = args.opt_free_from_str()?
@@ -159,7 +160,7 @@ fn main() -> Result<(), pico_args::Error> {
             println!("Checking two phase commit with {} resource managers using symmetry reduction.", rm_count);
             TwoPhaseSys { rms: 0..rm_count }.checker()
                 .threads(num_cpus::get()).symmetry().spawn_dfs()
-                .report(&mut std::io::stdout());
+                .report(&mut WriteReporter::new(&mut std::io::stdout()));
 
             // Implementing this trait enables symmetry reduction to speed up model checking (optional).
             impl Representative for TwoPhaseState {

--- a/examples/increment.rs
+++ b/examples/increment.rs
@@ -104,7 +104,7 @@
 //! State { i: 1, s: [{t: 0, pc: 3}, {t: 0, pc: 3}]}
 //! ```
 
-use stateright::*;
+use stateright::{*, report::WriteReporter};
 
 #[derive(Debug, Clone)]
 pub enum Action {
@@ -209,7 +209,7 @@ fn main() -> Result<(), pico_args::Error> {
                 .checker()
                 .threads(num_cpus::get())
                 .spawn_dfs()
-                .report(&mut std::io::stdout());
+                .report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("check-sym") => {
             let thread_count = args.opt_free_from_str()?.unwrap_or(3);
@@ -222,7 +222,7 @@ fn main() -> Result<(), pico_args::Error> {
                 .threads(num_cpus::get())
                 .symmetry()
                 .spawn_dfs()
-                .report(&mut std::io::stdout());
+                .report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("explore") => {
             let thread_count = args.opt_free_from_str()?.unwrap_or(3);

--- a/examples/increment_lock.rs
+++ b/examples/increment_lock.rs
@@ -1,4 +1,4 @@
-use stateright::*;
+use stateright::{*, report::WriteReporter};
 
 #[derive(Debug, Clone)]
 pub enum Action {
@@ -119,7 +119,7 @@ fn main() -> Result<(), pico_args::Error> {
                 .checker()
                 .threads(num_cpus::get())
                 .spawn_dfs()
-                .report(&mut std::io::stdout());
+                .report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("check-sym") => {
             let thread_count = args.opt_free_from_str()?.unwrap_or(3);
@@ -132,7 +132,7 @@ fn main() -> Result<(), pico_args::Error> {
                 .threads(num_cpus::get())
                 .symmetry()
                 .spawn_dfs()
-                .report(&mut std::io::stdout());
+                .report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("explore") => {
             let thread_count = args.opt_free_from_str()?.unwrap_or(3);

--- a/examples/linearizable-register.rs
+++ b/examples/linearizable-register.rs
@@ -8,6 +8,7 @@
 //! http://muratbuffalo.blogspot.com/2012/05/replicatedfault-tolerant-atomic-storage.html
 
 use serde::{Deserialize, Serialize};
+use stateright::report::WriteReporter;
 use std::borrow::Cow;
 use stateright::{Checker, Expectation, Model};
 use stateright::actor::{
@@ -304,7 +305,7 @@ fn main() -> Result<(), pico_args::Error> {
                     network,
                 }
                 .into_model().checker().threads(num_cpus::get())
-                .spawn_dfs().report(&mut std::io::stdout());
+                .spawn_dfs().report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("explore") => {
             let client_count = args.opt_free_from_str()?

--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -47,6 +47,7 @@
 //! the algorithm is typically described.
 
 use serde::{Deserialize, Serialize};
+use stateright::report::WriteReporter;
 use stateright::{Expectation, Model, Checker};
 use stateright::actor::{
     Actor, ActorModel, Id, majority, model_peers, Network,Out};
@@ -334,7 +335,7 @@ fn main() -> Result<(), pico_args::Error> {
                     network,
                 }
                 .into_model().checker().threads(num_cpus::get())
-                .spawn_dfs().report(&mut std::io::stdout());
+                .spawn_dfs().report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("explore") => {
             let client_count = args.opt_free_from_str()?

--- a/examples/single-copy-register.rs
+++ b/examples/single-copy-register.rs
@@ -1,6 +1,7 @@
 //! An actor system where each server exposes a rewritable single-copy register. Servers do not
 //! provide consensus.
 
+use stateright::report::WriteReporter;
 use stateright::{Checker, Expectation, Model};
 use stateright::actor::{Actor, ActorModel, Id, Network, Out};
 use stateright::actor::register::{
@@ -144,7 +145,7 @@ fn main() -> Result<(), pico_args::Error> {
                     network,
                 }
                 .into_model().checker().threads(num_cpus::get())
-                .spawn_dfs().report(&mut std::io::stdout());
+                .spawn_dfs().report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("explore") => {
             let client_count = args.opt_free_from_str()?

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -545,7 +545,7 @@ mod test_path {
 #[cfg(test)]
 mod test_report {
     use super::*;
-    use crate::test_util::linear_equation_solver::LinearEquation;
+    use crate::{report::WriteReporter, test_util::linear_equation_solver::LinearEquation};
 
     #[test]
     fn report_includes_property_names_and_paths() {
@@ -556,7 +556,7 @@ mod test_report {
         LinearEquation { a: 2, b: 10, c: 14 }
             .checker()
             .spawn_bfs()
-            .report(&mut written);
+            .report(&mut WriteReporter::new(&mut written));
         let output = String::from_utf8(written).unwrap();
         assert!(
             output.starts_with(
@@ -584,7 +584,7 @@ mod test_report {
         LinearEquation { a: 2, b: 10, c: 14 }
             .checker()
             .spawn_dfs()
-            .report(&mut written);
+            .report(&mut WriteReporter::new(&mut written));
         let output = String::from_utf8(written).unwrap();
         assert!(
             output.starts_with(

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -9,18 +9,36 @@ mod rewrite;
 mod rewrite_plan;
 mod visitor;
 
+use crate::report::{ReportData, ReportDiscovery, Reporter};
 use crate::{Expectation, Model};
 use std::collections::HashMap;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::time::Instant;
 
-pub use rewrite::*;
 pub use path::*;
 pub use representative::*;
+pub use rewrite::*;
 pub use rewrite_plan::*;
 pub use visitor::*;
+
+/// The classification of a property discovery.
+pub enum DiscoveryClassification {
+    /// An example has been found.
+    Example,
+    /// A counterexample has been found.
+    Counterexample,
+}
+
+impl Display for DiscoveryClassification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DiscoveryClassification::Example => write!(f, "example"),
+            DiscoveryClassification::Counterexample => write!(f, "counterexample"),
+        }
+    }
+}
 
 /// A [`Model`] [`Checker`] builder. Instantiable via the [`Model::checker`] method.
 ///
@@ -106,9 +124,10 @@ impl<M: Model> CheckerBuilder<M> {
     ///    states and fingerprints.
     /// - `GET /.states/.../{invalid-fingerprint}` returns 404.
     pub fn serve(self, addresses: impl std::net::ToSocketAddrs) -> std::sync::Arc<impl Checker<M>>
-    where M: 'static + Model + Send + Sync,
-          M::Action: Debug + Send + Sync,
-          M::State: Debug + Hash + Send + Sync,
+    where
+        M: 'static + Model + Send + Sync,
+        M::Action: Debug + Send + Sync,
+        M::State: Debug + Hash + Send + Sync,
     {
         explorer::serve(self, addresses)
     }
@@ -123,8 +142,9 @@ impl<M: Model> CheckerBuilder<M> {
     #[must_use = "Checkers run on background threads. \
                   Consider calling join() or report(...), for example."]
     pub fn spawn_bfs(self) -> impl Checker<M>
-    where M: Model + Send + Sync + 'static,
-          M::State: Hash + Send + Sync + 'static,
+    where
+        M: Model + Send + Sync + 'static,
+        M::State: Hash + Send + Sync + 'static,
     {
         bfs::BfsChecker::spawn(self)
     }
@@ -138,8 +158,9 @@ impl<M: Model> CheckerBuilder<M> {
     #[must_use = "Checkers run on background threads. \
                   Consider calling join() or report(...), for example."]
     pub fn spawn_dfs(self) -> impl Checker<M>
-    where M: Model + Send + Sync + 'static,
-          M::State: Hash + Send + Sync + 'static,
+    where
+        M: Model + Send + Sync + 'static,
+        M::State: Hash + Send + Sync + 'static,
     {
         dfs::DfsChecker::spawn(self)
     }
@@ -148,7 +169,8 @@ impl<M: Model> CheckerBuilder<M> {
     ///
     /// [model state]: crate::Model::State
     pub fn symmetry(self) -> Self
-    where M::State: Representative,
+    where
+        M::State: Representative,
     {
         self.symmetry_fn(Representative::representative)
     }
@@ -157,24 +179,36 @@ impl<M: Model> CheckerBuilder<M> {
     ///
     /// [model state]: crate::Model::State
     pub fn symmetry_fn(self, representative: fn(&M::State) -> M::State) -> Self {
-        Self { symmetry: Some(representative), .. self }
+        Self {
+            symmetry: Some(representative),
+            ..self
+        }
     }
 
     /// Sets the number of states that the checker should aim to generate. For performance reasons
     /// the checker may exceed this number, but it will never generate fewer states if more exist.
     pub fn target_state_count(self, count: usize) -> Self {
-        Self { target_state_count: NonZeroUsize::new(count), .. self }
+        Self {
+            target_state_count: NonZeroUsize::new(count),
+            ..self
+        }
     }
 
     /// Sets the number of threads available for model checking. For maximum performance this
     /// should match the number of cores.
     pub fn threads(self, thread_count: usize) -> Self {
-        Self { thread_count, .. self }
+        Self {
+            thread_count,
+            ..self
+        }
     }
 
     /// Indicates a function to be run on each evaluated state.
     pub fn visitor(self, visitor: impl CheckerVisitor<M> + Send + Sync + 'static) -> Self {
-        Self { visitor: Some(Box::new(visitor)), .. self }
+        Self {
+            visitor: Some(Box::new(visitor)),
+            ..self
+        }
     }
 }
 
@@ -214,85 +248,116 @@ pub trait Checker<M: Model> {
     }
 
     /// Periodically emits a status message.
-    fn report(self, w: &mut impl std::io::Write) -> Self
-    where M::Action: Debug,
-          M::State: Debug,
-          Self: Sized,
+    fn report<R>(self, reporter: &mut R) -> Self
+    where
+        M::Action: Debug,
+        M::State: Debug,
+        Self: Sized,
+        R: Reporter<M>,
     {
         // Start with the checking status.
         let method_start = Instant::now();
         while !self.is_done() {
-            let _ = writeln!(w, "Checking. states={}, unique={}",
-                             self.state_count(),
-                             self.unique_state_count());
+            reporter.report_checking(ReportData {
+                total_states: self.state_count(),
+                unique_states: self.unique_state_count(),
+                duration: method_start.elapsed(),
+                done: false,
+            });
             std::thread::sleep(std::time::Duration::from_millis(1_000));
         }
-        let _ = writeln!(w, "Done. states={}, unique={}, sec={}",
-                         self.state_count(),
-                         self.unique_state_count(),
-                         method_start.elapsed().as_secs());
+        reporter.report_checking(ReportData {
+            total_states: self.state_count(),
+            unique_states: self.unique_state_count(),
+            duration: method_start.elapsed(),
+            done: true,
+        });
 
         // Finish with a discovery summary.
+        let mut discoveries = HashMap::new();
         for (name, path) in self.discoveries() {
-            let _ = write!(w, "Discovered \"{}\" {} {}",
-                           name, self.discovery_classification(name), path);
+            let discovery = ReportDiscovery {
+                path,
+                classification: self.discovery_classification(name),
+            };
+            discoveries.insert(name, discovery);
         }
+        reporter.report_discoveries(discoveries);
 
         self
     }
 
     /// Indicates whether a discovery is an `"example"` or `"counterexample"`.
-    fn discovery_classification(&self, name: &str) -> &'static str {
+    fn discovery_classification(&self, name: &str) -> DiscoveryClassification {
         let properties = self.model().properties();
         let property = properties.iter().find(|p| p.name == name).unwrap();
         match property.expectation {
-            Expectation::Always | Expectation::Eventually => "counterexample",
-            Expectation::Sometimes => "example",
+            Expectation::Always | Expectation::Eventually => {
+                DiscoveryClassification::Counterexample
+            }
+            Expectation::Sometimes => DiscoveryClassification::Example,
         }
     }
 
     /// A helper that verifies examples exist for all `sometimes` properties and no counterexamples
     /// exist for any `always`/`eventually` properties.
     fn assert_properties(&self)
-    where M::Action: Debug,
-          M::State: Debug,
+    where
+        M::Action: Debug,
+        M::State: Debug,
     {
         for p in self.model().properties() {
             match p.expectation {
                 Expectation::Always => self.assert_no_discovery(p.name),
                 Expectation::Eventually => self.assert_no_discovery(p.name),
-                Expectation::Sometimes => { self.assert_any_discovery(p.name); },
+                Expectation::Sometimes => {
+                    self.assert_any_discovery(p.name);
+                }
             }
         }
     }
 
     /// Panics if a particular discovery is not found.
     fn assert_any_discovery(&self, name: &'static str) -> Path<M::State, M::Action> {
-        if let Some(found) = self.discovery(name) { return found }
-        assert!(self.is_done(),
-                "Discovery for \"{}\" not found, but model checking is incomplete.", name);
+        if let Some(found) = self.discovery(name) {
+            return found;
+        }
+        assert!(
+            self.is_done(),
+            "Discovery for \"{}\" not found, but model checking is incomplete.",
+            name
+        );
         panic!("Discovery for \"{}\" not found.", name);
     }
 
     /// Panics if a particular discovery is found.
     fn assert_no_discovery(&self, name: &'static str)
-    where M::Action: Debug,
-          M::State: Debug,
+    where
+        M::Action: Debug,
+        M::State: Debug,
     {
         if let Some(found) = self.discovery(name) {
-            panic!("Unexpected \"{}\" {} {}Last state: {:?}\n",
-                   name, self.discovery_classification(name), found, found.last_state());
+            panic!(
+                "Unexpected \"{}\" {} {}Last state: {:?}\n",
+                name,
+                self.discovery_classification(name),
+                found,
+                found.last_state()
+            );
         }
-        assert!(self.is_done(),
-                "Discovery for \"{}\" not found, but model checking is incomplete.",
-                name);
+        assert!(
+            self.is_done(),
+            "Discovery for \"{}\" not found, but model checking is incomplete.",
+            name
+        );
     }
 
     /// Panics if the specified actions do not result in a discovery for the specified property
     /// name.
     fn assert_discovery(&self, name: &'static str, actions: Vec<M::Action>)
-    where M::State: Debug + PartialEq,
-          M::Action: Debug + PartialEq,
+    where
+        M::State: Debug + PartialEq,
+        M::Action: Debug + PartialEq,
     {
         let mut additional_info: Vec<&'static str> = Vec::new();
 
@@ -302,28 +367,34 @@ pub trait Checker<M: Model> {
                 let property = self.model().property(name);
                 match property.expectation {
                     Expectation::Always => {
-                        if !(property.condition)(self.model(), path.last_state()) { return }
+                        if !(property.condition)(self.model(), path.last_state()) {
+                            return;
+                        }
                     }
                     Expectation::Eventually => {
                         let states = path.into_states();
-                        let is_liveness_satisfied = states.iter().any(|s| {
-                            (property.condition)(self.model(), s)
-                        });
+                        let is_liveness_satisfied =
+                            states.iter().any(|s| (property.condition)(self.model(), s));
                         let is_path_terminal = {
                             let mut actions = Vec::new();
                             self.model().actions(states.last().unwrap(), &mut actions);
                             actions.is_empty()
                         };
-                        if !is_liveness_satisfied && is_path_terminal { return }
+                        if !is_liveness_satisfied && is_path_terminal {
+                            return;
+                        }
                         if is_liveness_satisfied {
-                            additional_info.push("incorrect counterexample satisfies eventually property");
+                            additional_info
+                                .push("incorrect counterexample satisfies eventually property");
                         }
                         if !is_path_terminal {
                             additional_info.push("incorrect counterexample is nonterminal");
                         }
                     }
                     Expectation::Sometimes => {
-                        if (property.condition)(self.model(), path.last_state()) { return }
+                        if (property.condition)(self.model(), path.last_state()) {
+                            return;
+                        }
                     }
                 }
             }
@@ -333,8 +404,12 @@ pub trait Checker<M: Model> {
         } else {
             format!(" ({})", additional_info.join("; "))
         };
-        panic!("Invalid discovery for \"{}\"{}, but a valid one was found. found={:?}",
-               name, additional_info, found.into_actions());
+        panic!(
+            "Invalid discovery for \"{}\"{}, but a valid one was found. found={:?}",
+            name,
+            additional_info,
+            found.into_actions()
+        );
     }
 }
 
@@ -349,8 +424,8 @@ type EventuallyBits = id_set::IdSet;
 
 #[cfg(test)]
 mod test_eventually_property_checker {
-    use crate::{Checker, Property};
     use crate::test_util::dgraph::DGraph;
+    use crate::{Checker, Property};
 
     fn eventually_odd() -> Property<DGraph> {
         Property::eventually("odd", |_, s| s % 2 == 1)
@@ -359,58 +434,85 @@ mod test_eventually_property_checker {
     #[test]
     fn can_validate() {
         DGraph::with_property(eventually_odd())
-            .with_path(vec![1])        // satisfied at terminal init
-            .with_path(vec![2, 3])     // satisfied at nonterminal init
-            .with_path(vec![2, 6, 7])  // satisfied at terminal next
+            .with_path(vec![1]) // satisfied at terminal init
+            .with_path(vec![2, 3]) // satisfied at nonterminal init
+            .with_path(vec![2, 6, 7]) // satisfied at terminal next
             .with_path(vec![4, 9, 10]) // satisfied at nonterminal next
-            .check().assert_properties();
+            .check()
+            .assert_properties();
         // Repeat with distinct state spaces since stateful checking skips visited states (which we
         // don't expect here, but this is defense in depth).
         DGraph::with_property(eventually_odd())
-            .with_path(vec![1]).check().assert_properties();
+            .with_path(vec![1])
+            .check()
+            .assert_properties();
         DGraph::with_property(eventually_odd())
-            .with_path(vec![2, 3]).check().assert_properties();
+            .with_path(vec![2, 3])
+            .check()
+            .assert_properties();
         DGraph::with_property(eventually_odd())
-            .with_path(vec![2, 6, 7]).check().assert_properties();
+            .with_path(vec![2, 6, 7])
+            .check()
+            .assert_properties();
         DGraph::with_property(eventually_odd())
-            .with_path(vec![4, 9, 10]).check().assert_properties();
+            .with_path(vec![4, 9, 10])
+            .check()
+            .assert_properties();
     }
 
     #[test]
-    fn can_discover_counterexample() { // i.e. can falsify
+    fn can_discover_counterexample() {
+        // i.e. can falsify
         assert_eq!(
             DGraph::with_property(eventually_odd())
                 .with_path(vec![0, 1])
                 .with_path(vec![0, 2])
-                .check().discovery("odd").unwrap().into_states(),
-            vec![0, 2]);
+                .check()
+                .discovery("odd")
+                .unwrap()
+                .into_states(),
+            vec![0, 2]
+        );
         assert_eq!(
             DGraph::with_property(eventually_odd())
                 .with_path(vec![0, 1])
                 .with_path(vec![2, 4])
-                .check().discovery("odd").unwrap().into_states(),
-            vec![2, 4]);
+                .check()
+                .discovery("odd")
+                .unwrap()
+                .into_states(),
+            vec![2, 4]
+        );
         assert_eq!(
             DGraph::with_property(eventually_odd())
                 .with_path(vec![0, 1, 4, 6])
                 .with_path(vec![2, 4, 8])
-                .check().discovery("odd").unwrap().into_states(),
-            vec![2, 4, 6]);
+                .check()
+                .discovery("odd")
+                .unwrap()
+                .into_states(),
+            vec![2, 4, 6]
+        );
     }
 
     #[test]
-    fn fixme_can_miss_counterexample_when_revisiting_a_state() { // i.e. incorrectly verify
+    fn fixme_can_miss_counterexample_when_revisiting_a_state() {
+        // i.e. incorrectly verify
         assert_eq!(
             DGraph::with_property(eventually_odd())
                 .with_path(vec![0, 2, 4, 2]) // cycle
-                .check().discovery("odd"),
-            None); // FIXME: `unwrap().into_states()` should be [0, 2, 4, 2]
+                .check()
+                .discovery("odd"),
+            None
+        ); // FIXME: `unwrap().into_states()` should be [0, 2, 4, 2]
         assert_eq!(
             DGraph::with_property(eventually_odd())
                 .with_path(vec![0, 2, 4])
                 .with_path(vec![1, 4, 6]) // revisiting 4
-                .check().discovery("odd"),
-            None); // FIXME: `unwrap().into_states()` should be [0, 2, 4, 6]
+                .check()
+                .discovery("odd"),
+            None
+        ); // FIXME: `unwrap().into_states()` should be [0, 2, 4, 6]
     }
 }
 
@@ -432,12 +534,11 @@ mod test_path {
             fp(2, 1), // final state
         ]);
         let path = Path::from_fingerprints(&model, fingerprints.clone());
+        assert_eq!(path.last_state(), &(2, 1));
         assert_eq!(
             path.last_state(),
-            &(2,1));
-        assert_eq!(
-            path.last_state(),
-            &Path::final_state(&model, fingerprints).unwrap());
+            &Path::final_state(&model, fingerprints).unwrap()
+        );
     }
 }
 
@@ -452,34 +553,51 @@ mod test_report {
 
         // BFS
         let mut written: Vec<u8> = Vec::new();
-        LinearEquation { a: 2, b: 10, c: 14 }.checker()
-            .spawn_bfs().report(&mut written);
+        LinearEquation { a: 2, b: 10, c: 14 }
+            .checker()
+            .spawn_bfs()
+            .report(&mut written);
         let output = String::from_utf8(written).unwrap();
         assert!(
-            output.starts_with("\
+            output.starts_with(
+                "\
                 Checking. states=1, unique=1\n\
-                Done. states=15, unique=12, sec="),
-            "Output did not start as expected (see test). output={:?}`", output);
+                Done. states=15, unique=12, sec="
+            ),
+            "Output did not start as expected (see test). output={:?}`",
+            output
+        );
         assert!(
-            output.ends_with("\
+            output.ends_with(
+                "\
                 Discovered \"solvable\" example Path[3]:\n\
                 - IncreaseX\n\
                 - IncreaseX\n\
-                - IncreaseY\n"),
-            "Output did not end as expected (see test). output={:?}`", output);
+                - IncreaseY\n"
+            ),
+            "Output did not end as expected (see test). output={:?}`",
+            output
+        );
 
         // DFS
         let mut written: Vec<u8> = Vec::new();
-        LinearEquation { a: 2, b: 10, c: 14 }.checker()
-            .spawn_dfs().report(&mut written);
+        LinearEquation { a: 2, b: 10, c: 14 }
+            .checker()
+            .spawn_dfs()
+            .report(&mut written);
         let output = String::from_utf8(written).unwrap();
         assert!(
-            output.starts_with("\
+            output.starts_with(
+                "\
                 Checking. states=1, unique=1\n\
-                Done. states=55, unique=55, sec="),
-            "Output did not start as expected (see test). output={:?}`", output);
+                Done. states=55, unique=55, sec="
+            ),
+            "Output did not start as expected (see test). output={:?}`",
+            output
+        );
         assert!(
-            output.ends_with("\
+            output.ends_with(
+                "\
                 Discovered \"solvable\" example Path[27]:\n\
                 - IncreaseY\n\
                 - IncreaseY\n\
@@ -507,7 +625,10 @@ mod test_report {
                 - IncreaseY\n\
                 - IncreaseY\n\
                 - IncreaseY\n\
-                - IncreaseY\n"),
-            "Output did not end as expected (see test). output={:?}`", output);
+                - IncreaseY\n"
+            ),
+            "Output did not end as expected (see test). output={:?}`",
+            output
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@
 
 #[warn(anonymous_parameters)]
 #[warn(missing_docs)]
-
 mod checker;
+pub mod report;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::io::Write;
+use std::{io::Stdout, time::Duration};
+
+use crate::{DiscoveryClassification, Model, Path};
+
+/// The data sent during a report event.
+pub struct ReportData {
+    /// The total number of states.
+    pub total_states: usize,
+    /// The number of unique states found.
+    pub unique_states: usize,
+    /// The current duration checking has been running for.
+    pub duration: Duration,
+    /// Whether checking is done.
+    pub done: bool,
+}
+
+/// A discovery found during the checking.
+pub struct ReportDiscovery<M>
+where
+    M: Model,
+{
+    /// The path that led to the discovery.
+    pub path: Path<M::State, M::Action>,
+    /// The classification of the path.
+    pub classification: DiscoveryClassification,
+}
+
+/// A reporter for progress during the model checking.
+pub trait Reporter<M: Model> {
+    /// Report a progress event.
+    fn report_checking(&mut self, data: ReportData);
+
+    /// Report the discoveries at the end of the checking run.
+    fn report_discoveries(&mut self, discoveries: HashMap<&'static str, ReportDiscovery<M>>)
+    where
+        M::Action: Debug,
+        M::State: Debug;
+}
+
+impl<M: Model> Reporter<M> for Vec<u8> {
+    fn report_checking(&mut self, data: ReportData) {
+        if data.done {
+            let _ = writeln!(
+                self,
+                "Done. states={}, unique={}, sec={}",
+                data.total_states,
+                data.unique_states,
+                data.duration.as_secs()
+            );
+        } else {
+            let _ = writeln!(
+                self,
+                "Checking. states={}, unique={}",
+                data.total_states, data.unique_states
+            );
+        }
+    }
+
+    fn report_discoveries(&mut self, discoveries: HashMap<&'static str, ReportDiscovery<M>>)
+    where
+        M::Action: Debug,
+        M::State: Debug,
+    {
+        for (name, discovery) in discoveries {
+            let _ = write!(
+                self,
+                "Discovered \"{}\" {} {}",
+                name, discovery.classification, discovery.path,
+            );
+        }
+    }
+}
+
+impl<M: Model> Reporter<M> for Stdout {
+    fn report_checking(&mut self, data: ReportData) {
+        if data.done {
+            let _ = writeln!(
+                self,
+                "Done. states={}, unique={}, sec={}",
+                data.total_states,
+                data.unique_states,
+                data.duration.as_secs()
+            );
+        } else {
+            let _ = writeln!(
+                self,
+                "Checking. states={}, unique={}",
+                data.total_states, data.unique_states
+            );
+        }
+    }
+
+    fn report_discoveries(&mut self, discoveries: HashMap<&'static str, ReportDiscovery<M>>)
+    where
+        M::Action: Debug,
+        M::State: Debug,
+    {
+        for (name, discovery) in discoveries {
+            let _ = write!(
+                self,
+                "Discovered \"{}\" {} {}",
+                name, discovery.classification, discovery.path,
+            );
+        }
+    }
+}


### PR DESCRIPTION
The report function currently only writes a predefined output to stdout, in some cases it may make sense to provide more information in the report or even send it somewhere else.

This PR adds a new `Reporter` trait that encapsulates what data can be reported from the checking process.

In order to ease the transition it also includes a `WriteReporter`, a reporter that can write to anything that implements `Write` using the old format.

One thing that I've in particular wanted to report on is the rate of states being processed for instance.