### PR TITLE
Dynamic property feedback

### DIFF
--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -266,8 +266,8 @@ mod test {
     fn can_init() {
         let checker = Arc::new(BinaryClock.checker().spawn_bfs());
         assert_eq!(get_states(Arc::clone(&checker), "/").unwrap(), vec![
-            StateView { action: None, outcome: None, state: Some(0), properties: Vec::new(), svg: None },
-            StateView { action: None, outcome: None, state: Some(1), properties: Vec::new(), svg: None },
+            StateView { action: None, outcome: None, state: Some(0), properties: vec![(Expectation::Always, "in [0, 1]".to_owned(), None)], svg: None },
+            StateView { action: None, outcome: None, state: Some(1), properties: vec![(Expectation::Always, "in [0, 1]".to_owned(), None)], svg: None },
         ]);
     }
 
@@ -287,7 +287,7 @@ mod test {
                 action: Some("GoHigh".to_string()),
                 outcome: Some("1".to_string()),
                 state: Some(1),
-                properties: Vec::new(),
+                properties: vec![(Expectation::Always, "in [0, 1]".to_owned(), None)],
                 svg: None,
             },
         ]);
@@ -331,7 +331,14 @@ mod test {
                             Envelope { src: Id::from(0), dst: Id::from(1), msg: Ping(0) },
                         ]),
                     }),
-                    properties: Vec::new(),
+                    properties: vec![
+                        (Expectation::Always, "delta within 1".to_owned(), None), 
+                        (Expectation::Sometimes, "can reach max".to_owned(), None), 
+                        (Expectation::Eventually, "must reach max".to_owned(), None), 
+                        (Expectation::Eventually, "must exceed max".to_owned(), None), 
+                        (Expectation::Always, "#in <= #out".to_owned(), None), 
+                        (Expectation::Eventually, "#out <= #in + 1".to_owned(), None)
+                    ],
                     svg: Some("<svg version=\'1.1\' baseProfile=\'full\' width=\'500\' height=\'30\' viewbox=\'-20 -20 520 50\' xmlns=\'http://www.w3.org/2000/svg\'><defs><marker class=\'svg-event-shape\' id=\'arrow\' markerWidth=\'12\' markerHeight=\'10\' refX=\'12\' refY=\'5\' orient=\'auto\'><polygon points=\'0 0, 12 5, 0 10\' /></marker></defs><line x1=\'0\' y1=\'0\' x2=\'0\' y2=\'30\' class=\'svg-actor-timeline\' />\n<text x=\'0\' y=\'0\' class=\'svg-actor-label\'>0</text>\n<line x1=\'100\' y1=\'0\' x2=\'100\' y2=\'30\' class=\'svg-actor-timeline\' />\n<text x=\'100\' y=\'0\' class=\'svg-actor-label\'>1</text>\n</svg>\n".to_string()),
                 },
             ]);
@@ -363,7 +370,14 @@ mod test {
                     is_timer_set: vec![false,false],
                     network: Network::new_unordered_nonduplicating([]),
                 }),
-                properties: Vec::new(),
+                properties: vec![
+                    (Expectation::Always, "delta within 1".to_owned(), None), 
+                    (Expectation::Sometimes, "can reach max".to_owned(), None), 
+                    (Expectation::Eventually, "must reach max".to_owned(), None), 
+                    (Expectation::Eventually, "must exceed max".to_owned(), None), 
+                    (Expectation::Always, "#in <= #out".to_owned(), None), 
+                    (Expectation::Eventually, "#out <= #in + 1".to_owned(), None)
+                ],
                 svg: Some("<svg version='1.1' baseProfile='full' width='500' height='60' viewbox='-20 -20 520 80' xmlns='http://www.w3.org/2000/svg'><defs><marker class='svg-event-shape' id='arrow' markerWidth='12' markerHeight='10' refX='12' refY='5' orient='auto'><polygon points='0 0, 12 5, 0 10' /></marker></defs><line x1='0' y1='0' x2='0' y2='60' class='svg-actor-timeline' />\n<text x='0' y='0' class='svg-actor-label'>0</text>\n<line x1='100' y1='0' x2='100' y2='60' class='svg-actor-timeline' />\n<text x='100' y='0' class='svg-actor-label'>1</text>\n</svg>\n".to_string()),
             });
         assert_eq!(
@@ -382,7 +396,14 @@ mod test {
                         Envelope { src: Id::from(1), dst: Id::from(0), msg: Pong(0) },
                     ]),
                 }),
-                properties: Vec::new(),
+                properties: vec![
+                    (Expectation::Always, "delta within 1".to_owned(), None), 
+                    (Expectation::Sometimes, "can reach max".to_owned(), None), 
+                    (Expectation::Eventually, "must reach max".to_owned(), None), 
+                    (Expectation::Eventually, "must exceed max".to_owned(), None), 
+                    (Expectation::Always, "#in <= #out".to_owned(), None), 
+                    (Expectation::Eventually, "#out <= #in + 1".to_owned(), None)
+                ],
                 svg: Some("<svg version='1.1' baseProfile='full' width='500' height='60' viewbox='-20 -20 520 80' xmlns='http://www.w3.org/2000/svg'><defs><marker class='svg-event-shape' id='arrow' markerWidth='12' markerHeight='10' refX='12' refY='5' orient='auto'><polygon points='0 0, 12 5, 0 10' /></marker></defs><line x1='0' y1='0' x2='0' y2='60' class='svg-actor-timeline' />\n<text x='0' y='0' class='svg-actor-label'>0</text>\n<line x1='100' y1='0' x2='100' y2='60' class='svg-actor-timeline' />\n<text x='100' y='0' class='svg-actor-label'>1</text>\n<line x1='0' x2='100' y1='0' y2='30' marker-end='url(#arrow)' class='svg-event-line' />\n<text x='100' y='30' class='svg-event-label'>Ping(0)</text>\n</svg>\n".to_string()),
             });
     }

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -149,19 +149,13 @@ where M: Model,
         done: checker.is_done(),
         state_count: checker.state_count(),
         unique_state_count: checker.unique_state_count(),
-        properties: checker.model().properties().into_iter()
-            .map(|p| (
-                    p.expectation,
-                    p.name.to_string(),
-                    checker.discovery(p.name).map(|p| p.encode()),
-            ))
-            .collect(),
+        properties: get_properties(checker),
         recent_path: snapshot.read().1.as_ref().map(|p| format!("{:?}", p)),
     };
     Json(status)
 }
 
-fn properties_for_state<C, M>(checker: &Arc<C>) -> Vec<Property> 
+fn get_properties<C, M>(checker: &Arc<C>) -> Vec<Property> 
 where M: Model,
       M::State: Hash,
       C: Checker<M>,
@@ -213,7 +207,7 @@ where M: Model,
                 action: None,
                 outcome: None,
                 state: Some(state),
-                properties: properties_for_state(checker),
+                properties: get_properties(checker),
                 svg,
             });
         }
@@ -239,7 +233,7 @@ where M: Model,
                     action: Some(model.format_action(&action)),
                     outcome,
                     state: Some(state),
-                    properties: properties_for_state(checker),
+                    properties: get_properties(checker),
                     svg,
                 });
             } else {
@@ -248,7 +242,7 @@ where M: Model,
                     action: Some(model.format_action(&action)),
                     outcome: None,
                     state: None,
-                    properties: properties_for_state(checker),
+                    properties: get_properties(checker),
                     svg: None,
                 });
             }

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -49,6 +49,9 @@ where
             out.serialize_field("state", &format!("{:#?}", state))?;
             out.serialize_field("fingerprint", &format!("{:?}", fingerprint(&state)))?;
         }
+        if !self.properties.is_empty() {
+            out.serialize_field("properties", &self.properties)?;
+        }
         if let Some(ref svg) = self.svg {
             out.serialize_field("svg", svg)?;
         }

--- a/ui/app.js
+++ b/ui/app.js
@@ -183,6 +183,8 @@ function App() {
     app.farthestStep = ko.observable(Step.PRE_INIT);
     app.isCompact = ko.observable(false);
     app.isCompleteState = ko.observable(false);
+    app.showPerStateProperties = ko.observable(false);
+    app.showCurrentStateProperties = ko.observable(false);
     app.isSameStateAsSelected = (step) => step.state == app.selectedStep().state;
     app.onKeyDown = (data, ev) => {
         switch (ev.keyCode) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -69,10 +69,10 @@ function getPropertyForState(p, path) {
     const [ icon, summary ] = (() => {
         if (discoveryPath) {
             if (discoveryPath.length + 1 < path.length) {
-                // state before discovery
+                // state after discovery
                 return ['⬆️', ''];
             } else if (discoveryPath.length + 1 > path.length) {
-                // state after discovery
+                // state before discovery
                 return ['⬇️', ''];
             } else {
                 switch (expectation) {

--- a/ui/index.htm
+++ b/ui/index.htm
@@ -41,6 +41,7 @@
             </ul>
 
             <h2>Properties</h2>
+            <h3>Global</h3>
             <ul data-bind="foreach: {
                                                 data: status().properties,
                                                 as: 'p',
@@ -61,6 +62,19 @@
                 </li>
             </ul>
 
+            <h3>Current state</h3>
+            <ul data-bind="foreach: {
+                                                data: selectedStep().properties,
+                                                as: 'p',
+                                                noChildContext: true,
+                                              }">
+                <li>
+                    <b data-bind="text: p.icon + ' ' + p.summary">SUMMARY</b>
+                    <span class="font-code"
+                          data-bind="text: p.expectation + ' ' + p.name">PROPERTY</span>
+                </li>
+            </ul>
+
             <h2>Path of Actions</h2>
             <ol class="path-list" data-bind="foreach: farthestStep().pathSteps()">
                 <li>
@@ -71,7 +85,7 @@
                                     'is-same-state': $data != $root.selectedStep()
                                                   && $root.isSameStateAsSelected($data)
                                   },
-                                  text: $data.action">PREV</a>
+                                  text: $data.icons + ' ' + $data.action">PREV</a>
                 </li>
             </ol>
 
@@ -87,7 +101,7 @@
                                     'is-ignored': $data.isIgnored,
                                     'is-same-state': $root.isSameStateAsSelected($data),
                                   },
-                                  text: $data.action">NEXT</a>
+                                  text: $data.icons + ' ' + $data.action">NEXT</a>
                 </li>
             </ul>
         </nav>

--- a/ui/index.htm
+++ b/ui/index.htm
@@ -40,7 +40,18 @@
                 </li>
             </ul>
 
-            <h2>Properties</h2>
+            <div class="heading-with-controls">
+                <h2>Properties</h2>
+                <label>
+                    <input type="checkbox" data-bind="checked: showCurrentStateProperties" />
+                    Current state?
+                </label>
+                <label>
+                    <input type="checkbox" data-bind="checked: showPerStateProperties" />
+                    Per-state?
+                </label>
+            </div>
+
             <h3>Global</h3>
             <ul data-bind="foreach: {
                                                 data: status().properties,
@@ -62,6 +73,7 @@
                 </li>
             </ul>
 
+            <!-- ko if: showCurrentStateProperties -->
             <h3>Current state</h3>
             <ul data-bind="foreach: {
                                                 data: selectedStep().properties,
@@ -74,6 +86,7 @@
                           data-bind="text: p.expectation + ' ' + p.name">PROPERTY</span>
                 </li>
             </ul>
+            <!-- /ko -->
 
             <h2>Path of Actions</h2>
             <ol class="path-list" data-bind="foreach: farthestStep().pathSteps()">
@@ -85,7 +98,7 @@
                                     'is-same-state': $data != $root.selectedStep()
                                                   && $root.isSameStateAsSelected($data)
                                   },
-                                  text: $data.icons + ' ' + $data.action">PREV</a>
+                                  text: ($root.showPerStateProperties() ? $data.icons + ' ' : '') + $data.action">PREV</a>
                 </li>
             </ol>
 
@@ -101,7 +114,7 @@
                                     'is-ignored': $data.isIgnored,
                                     'is-same-state': $root.isSameStateAsSelected($data),
                                   },
-                                  text: $data.icons + ' ' + $data.action">NEXT</a>
+                                  text: ($root.showPerStateProperties() ? $data.icons + ' ' : '') + $data.action">NEXT</a>
                 </li>
             </ul>
         </nav>


### PR DESCRIPTION
- Adds properties field per-state in the explorer API
- Renders property icons per-state (toggleable)
- Renders properties for currently selected state (toggleable)
- Renders breadcrumbs for states on a path to a discovery

Fixes #22 