### PR TITLE
Add an on-demand checker

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -137,10 +137,8 @@ impl<M: Model> CheckerBuilder<M> {
     }
 
     /// Spawns an on-demand model checker. This traversal strategy doesn't compute any states until
-    /// it is asked to, useful for lightweight exploration.
-    /// [`CheckerBuilder::spawn_dfs`] but will find the shortest [`Path`] to each discovery if
-    /// checking is single threadeded (the default behavior, which [`CheckerBuilder::threads`]
-    /// overrides).
+    /// it is asked to, useful for lightweight exploration. Internally the exploration strategy is
+    /// very similar to that of [`CheckerBuilder::spawn_bfs`].
     ///
     /// This call does not block the current thread. Call [`Checker::join`] to block until checking
     /// completes.

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -10,7 +10,7 @@ mod rewrite;
 mod rewrite_plan;
 mod visitor;
 
-use crate::{Expectation, Model};
+use crate::{Expectation, Model, Fingerprint};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -204,6 +204,11 @@ impl<M: Model> CheckerBuilder<M> {
 pub trait Checker<M: Model> {
     /// Returns a reference to this checker's [`Model`].
     fn model(&self) -> &M;
+
+    /// Asks the checker to check the given fingerprint if not done already.
+    fn check_fingerprint(&self, _fingerprint: Fingerprint) {
+        // nothing to do for most cases
+    }
 
     /// Indicate how many states have been generated including repeats. Always greater than or
     /// equal to [`Checker::unique_state_count`].

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -23,6 +23,12 @@ pub use representative::*;
 pub use rewrite_plan::*;
 pub use visitor::*;
 
+#[derive(Clone, Copy)]
+pub(crate) enum ControlFlow {
+    CheckFingerprint(Fingerprint),
+    RunToCompletion,
+}
+
 /// A [`Model`] [`Checker`] builder. Instantiable via the [`Model::checker`] method.
 ///
 /// # Example

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -210,6 +210,11 @@ pub trait Checker<M: Model> {
         // nothing to do for most cases
     }
 
+    /// Asks the checker to run to completion, no longer waiting for fingerprints.
+    fn run_to_completion(&self) {
+        // nothing to do for most cases
+    }
+
     /// Indicate how many states have been generated including repeats. Always greater than or
     /// equal to [`Checker::unique_state_count`].
     fn state_count(&self) -> usize;

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -3,6 +3,7 @@
 mod bfs;
 mod dfs;
 mod explorer;
+mod on_demand;
 mod path;
 mod representative;
 mod rewrite;
@@ -127,6 +128,24 @@ impl<M: Model> CheckerBuilder<M> {
           M::State: Hash + Send + Sync + 'static,
     {
         bfs::BfsChecker::spawn(self)
+    }
+
+    /// Spawns an on-demand model checker. This traversal strategy doesn't compute any states until
+    /// it is asked to, useful for lightweight exploration.
+    /// [`CheckerBuilder::spawn_dfs`] but will find the shortest [`Path`] to each discovery if
+    /// checking is single threadeded (the default behavior, which [`CheckerBuilder::threads`]
+    /// overrides).
+    ///
+    /// This call does not block the current thread. Call [`Checker::join`] to block until checking
+    /// completes.
+    #[must_use = "Checkers run on background threads. \
+                  Consider calling join() or report(...), for example."]
+    pub fn spawn_on_demand(self) -> impl Checker<M>
+    where
+        M: Model + Send + Sync + 'static,
+        M::State: Hash + Send + Sync + 'static,
+    {
+        on_demand::OnDemandChecker::spawn(self)
     }
 
     /// Spawns a depth-first search model checker. This traversal strategy uses dramatically less

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -118,6 +118,7 @@ where M: 'static + Model + Send + Sync,
         App::new()
             .data(Arc::clone(&data))
             .route("/.status", web::get().to(status::<M, C>))
+            .route("/.runtocompletion", web::post().to(run_to_completion::<M, C>))
             .route("/.states{fingerprints:.*}", web::get().to(states::<M, C>))
             .route("/", get_ui_file!("index.htm"))
             .route("/app.css", get_ui_file!("app.css"))
@@ -154,6 +155,16 @@ where M: Model,
         recent_path: snapshot.read().1.as_ref().map(|p| format!("{:?}", p)),
     };
     Json(status)
+}
+
+fn run_to_completion<M, C>(_: HttpRequest, data: Data<M::Action, C>)
+where M: Model,
+      M::Action: Debug,
+      M::State: Hash,
+      C: Checker<M>,
+{
+    let checker = &data.1;
+    checker.run_to_completion();
 }
 
 fn states<M, C>(req: HttpRequest, data: Data<M::Action, C>)

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -84,7 +84,7 @@ where M: 'static + Model + Send + Sync,
     });
     let checker = checker_builder
         .visitor(snapshot_for_visitor)
-        .spawn_bfs();
+        .spawn_on_demand();
     serve_checker(checker, snapshot_for_server, addresses)
 }
 

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -1,7 +1,9 @@
 //! Private module for selective re-export.
 
 use crate::checker::{Checker, EventuallyBits, Expectation, Path};
-use crate::{fingerprint, CheckerBuilder, CheckerVisitor, Fingerprint, Model, Property};
+use crate::{
+    fingerprint, CheckerBuilder, CheckerVisitor, ControlFlow, Fingerprint, Model, Property,
+};
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use nohash_hasher::NoHashHasher;
@@ -13,12 +15,6 @@ use std::sync::Arc;
 
 // While this file is currently quite similar to dfs.rs, a refactoring to lift shared
 // behavior is being postponed until DPOR is implemented.
-
-#[derive(Clone, Copy)]
-pub(crate) enum ControlFlow {
-    CheckFingerprint(Fingerprint),
-    RunToCompletion,
-}
 
 pub(crate) struct OnDemandChecker<M: Model> {
     // Immutable state.

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -1,0 +1,479 @@
+//! Private module for selective re-export.
+
+use crate::checker::{Checker, EventuallyBits, Expectation, Path};
+use crate::{fingerprint, CheckerBuilder, CheckerVisitor, Fingerprint, Model, Property};
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use nohash_hasher::NoHashHasher;
+use parking_lot::{Condvar, Mutex};
+use std::collections::{HashMap, VecDeque};
+use std::hash::{BuildHasherDefault, Hash};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+// While this file is currently quite similar to dfs.rs, a refactoring to lift shared
+// behavior is being postponed until DPOR is implemented.
+
+pub(crate) struct OnDemandChecker<M: Model> {
+    // Immutable state.
+    model: Arc<M>,
+    thread_count: usize,
+    handles: Vec<std::thread::JoinHandle<()>>,
+
+    // Mutable state.
+    job_market: Arc<Mutex<JobMarket<M::State>>>,
+    state_count: Arc<AtomicUsize>,
+    generated:
+        Arc<DashMap<Fingerprint, Option<Fingerprint>, BuildHasherDefault<NoHashHasher<u64>>>>,
+    discoveries: Arc<DashMap<&'static str, Fingerprint>>,
+}
+struct JobMarket<State> {
+    wait_count: usize,
+    jobs: Vec<Job<State>>,
+}
+type Job<State> = VecDeque<(State, Fingerprint, EventuallyBits)>;
+
+impl<M> OnDemandChecker<M>
+where
+    M: Model + Send + Sync + 'static,
+    M::State: Hash + Send + 'static,
+{
+    pub(crate) fn spawn(options: CheckerBuilder<M>) -> Self {
+        let model = Arc::new(options.model);
+        let target_state_count = options.target_state_count;
+        let thread_count = options.thread_count;
+        let visitor = Arc::new(options.visitor);
+        let property_count = model.properties().len();
+
+        let init_states: Vec<_> = model
+            .init_states()
+            .into_iter()
+            .filter(|s| model.within_boundary(s))
+            .collect();
+        let state_count = Arc::new(AtomicUsize::new(init_states.len()));
+        let generated = Arc::new({
+            let generated = DashMap::default();
+            for s in &init_states {
+                generated.insert(fingerprint(s), None);
+            }
+            generated
+        });
+        let ebits = {
+            let mut ebits = EventuallyBits::new();
+            for (i, p) in model.properties().iter().enumerate() {
+                if let Property {
+                    expectation: Expectation::Eventually,
+                    ..
+                } = p
+                {
+                    ebits.insert(i);
+                }
+            }
+            ebits
+        };
+        let pending: VecDeque<_> = init_states
+            .into_iter()
+            .map(|s| {
+                let fp = fingerprint(&s);
+                (s, fp, ebits.clone())
+            })
+            .collect();
+        let discoveries = Arc::new(DashMap::default());
+        let mut handles = Vec::new();
+
+        let has_new_job = Arc::new(Condvar::new());
+        let job_market = Arc::new(Mutex::new(JobMarket {
+            wait_count: thread_count,
+            jobs: vec![pending],
+        }));
+        for t in 0..thread_count {
+            let model = Arc::clone(&model);
+            let visitor = Arc::clone(&visitor);
+            let has_new_job = Arc::clone(&has_new_job);
+            let job_market = Arc::clone(&job_market);
+            let state_count = Arc::clone(&state_count);
+            let generated = Arc::clone(&generated);
+            let discoveries = Arc::clone(&discoveries);
+            handles.push(std::thread::spawn(move || {
+                log::debug!("{}: Thread started.", t);
+                let mut pending = VecDeque::new();
+                loop {
+                    // Step 1: Do work.
+                    if pending.is_empty() {
+                        pending = {
+                            let mut job_market = job_market.lock();
+                            match job_market.jobs.pop() {
+                                None => {
+                                    // Done if all are waiting.
+                                    if job_market.wait_count == thread_count {
+                                        log::debug!(
+                                            "{}: No more work. Shutting down... gen={}",
+                                            t,
+                                            generated.len()
+                                        );
+                                        has_new_job.notify_all();
+                                        return;
+                                    }
+
+                                    // Otherwise more work may become available.
+                                    log::trace!(
+                                        "{}: No jobs. Awaiting. blocked={}",
+                                        t,
+                                        job_market.wait_count
+                                    );
+                                    has_new_job.wait(&mut job_market);
+                                    continue;
+                                }
+                                Some(job) => {
+                                    job_market.wait_count -= 1;
+                                    log::trace!(
+                                        "{}: Job found. size={}, blocked={}",
+                                        t,
+                                        job.len(),
+                                        job_market.wait_count
+                                    );
+                                    job
+                                }
+                            }
+                        };
+                    }
+                    Self::check_block(
+                        &*model,
+                        &*state_count,
+                        &*generated,
+                        &mut pending,
+                        &*discoveries,
+                        &*visitor,
+                        1500,
+                    );
+                    if discoveries.len() == property_count {
+                        log::debug!(
+                            "{}: Discovery complete. Shutting down... gen={}",
+                            t,
+                            generated.len()
+                        );
+                        let mut job_market = job_market.lock();
+                        job_market.wait_count += 1;
+                        drop(job_market);
+                        has_new_job.notify_all();
+                        return;
+                    }
+                    if let Some(target_state_count) = target_state_count {
+                        if target_state_count.get() <= state_count.load(Ordering::Relaxed) {
+                            log::debug!(
+                                "{}: Reached target state count. Shutting down... gen={}",
+                                t,
+                                generated.len()
+                            );
+                            return;
+                        }
+                    }
+
+                    // Step 2: Share work.
+                    if pending.len() > 1 && thread_count > 1 {
+                        let mut job_market = job_market.lock();
+                        let pieces =
+                            1 + std::cmp::min(job_market.wait_count as usize, pending.len());
+                        let size = pending.len() / pieces;
+                        for _ in 1..pieces {
+                            log::trace!(
+                                "{}: Sharing work. blocked={}, size={}",
+                                t,
+                                job_market.wait_count,
+                                size
+                            );
+                            job_market
+                                .jobs
+                                .push(pending.split_off(pending.len() - size));
+                            has_new_job.notify_one();
+                        }
+                    } else if pending.is_empty() {
+                        let mut job_market = job_market.lock();
+                        job_market.wait_count += 1;
+                    }
+                }
+            }));
+        }
+        OnDemandChecker {
+            model,
+            thread_count,
+            handles,
+            job_market,
+            state_count,
+            generated,
+            discoveries,
+        }
+    }
+
+    fn check_block(
+        model: &M,
+        state_count: &AtomicUsize,
+        generated: &DashMap<
+            Fingerprint,
+            Option<Fingerprint>,
+            BuildHasherDefault<NoHashHasher<u64>>,
+        >,
+        pending: &mut Job<M::State>,
+        discoveries: &DashMap<&'static str, Fingerprint>,
+        visitor: &Option<Box<dyn CheckerVisitor<M> + Send + Sync>>,
+        mut max_count: usize,
+    ) {
+        let properties = model.properties();
+
+        let mut actions = Vec::new();
+        loop {
+            // Done if reached max count.
+            if max_count == 0 {
+                return;
+            }
+            max_count -= 1;
+
+            // Done if none pending.
+            let (state, state_fp, mut ebits) = match pending.pop_back() {
+                None => return,
+                Some(pair) => pair,
+            };
+            if let Some(visitor) = visitor {
+                visitor.visit(model, reconstruct_path(model, generated, state_fp));
+            }
+
+            // Done if discoveries found for all properties.
+            let mut is_awaiting_discoveries = false;
+            for (i, property) in properties.iter().enumerate() {
+                if discoveries.contains_key(property.name) {
+                    continue;
+                }
+                match property {
+                    Property {
+                        expectation: Expectation::Always,
+                        condition: always,
+                        ..
+                    } => {
+                        if !always(model, &state) {
+                            // Races other threads, but that's fine.
+                            discoveries.insert(property.name, state_fp);
+                        } else {
+                            is_awaiting_discoveries = true;
+                        }
+                    }
+                    Property {
+                        expectation: Expectation::Sometimes,
+                        condition: sometimes,
+                        ..
+                    } => {
+                        if sometimes(model, &state) {
+                            // Races other threads, but that's fine.
+                            discoveries.insert(property.name, state_fp);
+                        } else {
+                            is_awaiting_discoveries = true;
+                        }
+                    }
+                    Property {
+                        expectation: Expectation::Eventually,
+                        condition: eventually,
+                        ..
+                    } => {
+                        // The checker early exits after finding discoveries for every property,
+                        // and "eventually" property discoveries are only identifid at terminal
+                        // states, so if we are here it means we are still awaiting a corresponding
+                        // discovery regardless of whether the eventually property is now satisfied
+                        // (i.e. it might be falsifiable via a different path).
+                        is_awaiting_discoveries = true;
+                        if eventually(model, &state) {
+                            ebits.remove(i);
+                        }
+                    }
+                }
+            }
+            if !is_awaiting_discoveries {
+                return;
+            }
+
+            // Otherwise enqueue newly generated states (with related metadata).
+            let mut is_terminal = true;
+            model.actions(&state, &mut actions);
+            let next_states = actions.drain(..).flat_map(|a| model.next_state(&state, a));
+            for next_state in next_states {
+                // Skip if outside boundary.
+                if !model.within_boundary(&next_state) {
+                    continue;
+                }
+                state_count.fetch_add(1, Ordering::Relaxed);
+
+                // Skip if already generated.
+                //
+                // FIXME: we should really include ebits in the fingerprint here --
+                // it is possible to arrive at a DAG join with two different ebits
+                // values, and subsequently treat the fact that some eventually
+                // property held on the path leading to the first visit as meaning
+                // that it holds in the path leading to the second visit -- another
+                // possible false-negative.
+                let next_fingerprint = fingerprint(&next_state);
+                if let Entry::Vacant(next_entry) = generated.entry(next_fingerprint) {
+                    next_entry.insert(Some(state_fp));
+                } else {
+                    // FIXME: arriving at an already-known state may be a loop (in which case it
+                    // could, in a fancier implementation, be considered a terminal state for
+                    // purposes of eventually-property checking) but it might also be a join in
+                    // a DAG, which makes it non-terminal. These cases can be disambiguated (at
+                    // some cost), but for now we just _don't_ treat them as terminal, and tell
+                    // users they need to explicitly ensure model path-acyclicality when they're
+                    // using eventually properties (using a boundary or empty actions or
+                    // whatever).
+                    is_terminal = false;
+                    continue;
+                }
+
+                // Otherwise further checking is applicable.
+                is_terminal = false;
+                pending.push_front((next_state, next_fingerprint, ebits.clone()));
+            }
+            if is_terminal {
+                for (i, property) in properties.iter().enumerate() {
+                    if ebits.contains(i) {
+                        // Races other threads, but that's fine.
+                        discoveries.insert(property.name, state_fp);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<M> Checker<M> for OnDemandChecker<M>
+where
+    M: Model,
+    M::State: Hash,
+{
+    fn model(&self) -> &M {
+        &self.model
+    }
+
+    fn state_count(&self) -> usize {
+        self.state_count.load(Ordering::Relaxed)
+    }
+
+    fn unique_state_count(&self) -> usize {
+        self.generated.len()
+    }
+
+    fn discoveries(&self) -> HashMap<&'static str, Path<M::State, M::Action>> {
+        self.discoveries
+            .iter()
+            .map(|mapref| {
+                (
+                    <&'static str>::clone(mapref.key()),
+                    reconstruct_path(self.model(), &*self.generated, *mapref.value()),
+                )
+            })
+            .collect()
+    }
+
+    fn join(mut self) -> Self {
+        for h in self.handles.drain(0..) {
+            h.join().unwrap();
+        }
+        self
+    }
+
+    fn is_done(&self) -> bool {
+        let job_market = self.job_market.lock();
+        job_market.jobs.is_empty() && job_market.wait_count == self.thread_count
+            || self.discoveries.len() == self.model.properties().len()
+    }
+}
+
+fn reconstruct_path<M>(
+    model: &M,
+    generated: &DashMap<Fingerprint, Option<Fingerprint>, BuildHasherDefault<NoHashHasher<u64>>>,
+    fp: Fingerprint,
+) -> Path<M::State, M::Action>
+where
+    M: Model,
+    M::State: Hash,
+{
+    // First build a stack of digests representing the path (with the init digest at top of
+    // stack). Then unwind the stack of digests into a vector of states. The TLC model checker
+    // uses a similar technique, which is documented in the paper "Model Checking TLA+
+    // Specifications" by Yu, Manolios, and Lamport.
+
+    let mut fingerprints = VecDeque::new();
+    let mut next_fp = fp;
+    while let Some(source) = generated.get(&next_fp) {
+        match *source {
+            Some(prev_fingerprint) => {
+                fingerprints.push_front(next_fp);
+                next_fp = prev_fingerprint;
+            }
+            None => {
+                fingerprints.push_front(next_fp);
+                break;
+            }
+        }
+    }
+    Path::from_fingerprints(model, fingerprints)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_util::linear_equation_solver::*;
+    use crate::*;
+
+    #[test]
+    fn visits_states_in_bfs_order() {
+        let (recorder, accessor) = StateRecorder::new_with_accessor();
+        LinearEquation { a: 2, b: 10, c: 14 }
+            .checker()
+            .visitor(recorder)
+            .spawn_bfs()
+            .join();
+        assert_eq!(
+            accessor(),
+            vec![
+                (0, 0), // distance == 0
+                (1, 0),
+                (0, 1), // distance == 1
+                (2, 0),
+                (1, 1),
+                (0, 2), // distance == 2
+                (3, 0),
+                (2, 1), // distance == 3
+            ]
+        );
+    }
+
+    #[test]
+    fn can_complete_by_enumerating_all_states() {
+        let checker = LinearEquation { a: 2, b: 4, c: 7 }
+            .checker()
+            .spawn_bfs()
+            .join();
+        assert_eq!(checker.is_done(), true);
+        checker.assert_no_discovery("solvable");
+        assert_eq!(checker.unique_state_count(), 256 * 256);
+    }
+
+    #[test]
+    fn can_complete_by_eliminating_properties() {
+        let checker = LinearEquation { a: 2, b: 10, c: 14 }
+            .checker()
+            .spawn_bfs()
+            .join();
+        checker.assert_properties();
+        assert_eq!(checker.unique_state_count(), 12);
+
+        // bfs found this example...
+        assert_eq!(
+            checker.discovery("solvable").unwrap().into_actions(),
+            // (2*2 + 10*1) % 256 == 14
+            vec![Guess::IncreaseX, Guess::IncreaseX, Guess::IncreaseY,]
+        );
+        // ... but there are of course other solutions, such as the following.
+        checker.assert_discovery(
+            "solvable",
+            // (2*0 + 10*27) % 256 == 14
+            vec![Guess::IncreaseY; 27],
+        );
+    }
+}

--- a/ui/app.js
+++ b/ui/app.js
@@ -204,10 +204,16 @@ function App() {
                     for (let offset = parseInt(qsVal); offset > 0; --offset) {
                         app.selectedStep(app.selectedStep().prevStep);
                     }
-                    break; 
+                    break;
             }
         }
     }
+}
+
+async function runToCompletion() {
+    console.log("continuing checker");
+    let response = await fetch('/.runtocompletion', {method:'POST'});
+    console.log(response);
 }
 
 window.app = new App();

--- a/ui/index.htm
+++ b/ui/index.htm
@@ -19,8 +19,10 @@
     </header>
     <main class="main-flex">
         <nav class="main-flex-left">
+            <div class="heading-with-controls">
             <h2>Status</h2>
             <button type="submit" onclick="runToCompletion()">Run to completion</button>
+            </div>
             <ul data-bind="with: status">
                 <li>
                     <label>Model:</label>

--- a/ui/index.htm
+++ b/ui/index.htm
@@ -20,6 +20,7 @@
     <main class="main-flex">
         <nav class="main-flex-left">
             <h2>Status</h2>
+            <button type="submit" onclick="runToCompletion()">Run to completion</button>
             <ul data-bind="with: status">
                 <li>
                     <label>Model:</label>


### PR DESCRIPTION
This checker waits for requests to check fingerprints before doing the checking. This makes exploring less resource-intensive, without the need to check every state to just explore a few paths.

There is a 'run to completion' button in the UI for letting the checker run without waiting, back to the normal functionality.

The checker itself is mostly a copy of the BFS checker, besides the modifications to wait for fingerprints.

A potential future change would be to merge this control-flow functionality into both the DFS and BFS checkers directly