### PR TITLE
Add depth tracking and limiting

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -271,6 +271,9 @@ pub trait Checker<M: Model> {
     /// [`Checker::state_count`].
     fn unique_state_count(&self) -> usize;
 
+    /// Indicates the maximum depth that has been explored.
+    fn max_depth(&self) -> usize;
+
     /// Returns a map from property name to corresponding "discovery" (indicated
     /// by a [`Path`]).
     fn discoveries(&self) -> HashMap<&'static str, Path<M::State, M::Action>>;
@@ -304,6 +307,7 @@ pub trait Checker<M: Model> {
             reporter.report_checking(ReportData {
                 total_states: self.state_count(),
                 unique_states: self.unique_state_count(),
+                max_depth: self.max_depth(),
                 duration: method_start.elapsed(),
                 done: false,
             });
@@ -312,6 +316,7 @@ pub trait Checker<M: Model> {
         reporter.report_checking(ReportData {
             total_states: self.state_count(),
             unique_states: self.unique_state_count(),
+            max_depth: self.max_depth(),
             duration: method_start.elapsed(),
             done: true,
         });

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -62,6 +62,7 @@ pub struct CheckerBuilder<M: Model> {
     #[allow(clippy::type_complexity)]
     symmetry: Option<fn(&M::State) -> M::State>,
     target_state_count: Option<NonZeroUsize>,
+    target_max_depth: Option<NonZeroUsize>,
     thread_count: usize,
     visitor: Option<Box<dyn CheckerVisitor<M> + Send + Sync>>,
 }
@@ -70,6 +71,7 @@ impl<M: Model> CheckerBuilder<M> {
         Self {
             model,
             target_state_count: None,
+            target_max_depth: None,
             symmetry: None,
             thread_count: 1,
             visitor: None,
@@ -213,6 +215,14 @@ impl<M: Model> CheckerBuilder<M> {
     pub fn target_state_count(self, count: usize) -> Self {
         Self {
             target_state_count: NonZeroUsize::new(count),
+            ..self
+        }
+    }
+
+    /// Sets the maximum depth that the checker should aim to explore.
+    pub fn target_max_depth(self, depth: usize) -> Self {
+        Self {
+            target_max_depth: NonZeroUsize::new(depth),
             ..self
         }
     }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -609,8 +609,8 @@ mod test_report {
         assert!(
             output.starts_with(
                 "\
-                Checking. states=1, unique=1\n\
-                Done. states=15, unique=12, sec="
+                Checking. states=1, unique=1, depth=0\n\
+                Done. states=15, unique=12, depth=4, sec="
             ),
             "Output did not start as expected (see test). output={:?}`",
             output
@@ -637,8 +637,8 @@ mod test_report {
         assert!(
             output.starts_with(
                 "\
-                Checking. states=1, unique=1\n\
-                Done. states=55, unique=55, sec="
+                Checking. states=1, unique=1, depth=0\n\
+                Done. states=55, unique=55, depth=28, sec="
             ),
             "Output did not start as expected (see test). output={:?}`",
             output

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -23,6 +23,7 @@ pub(crate) struct DfsChecker<M: Model> {
     // Mutable state.
     job_market: Arc<Mutex<JobMarket<M::State>>>,
     state_count: Arc<AtomicUsize>,
+    max_depth: Arc<AtomicUsize>,
     generated: Arc<DashSet<Fingerprint, BuildHasherDefault<NoHashHasher<u64>>>>,
     discoveries: Arc<DashMap<&'static str, Vec<Fingerprint>>>,
 }
@@ -46,6 +47,7 @@ where M: Model + Send + Sync + 'static,
             .filter(|s| model.within_boundary(s))
             .collect();
         let state_count = Arc::new(AtomicUsize::new(init_states.len()));
+        let max_depth = Arc::new(AtomicUsize::new(0));
         let generated = Arc::new({
             let generated = DashSet::default();
             for s in &init_states {
@@ -86,6 +88,7 @@ where M: Model + Send + Sync + 'static,
             let has_new_job = Arc::clone(&has_new_job);
             let job_market = Arc::clone(&job_market);
             let state_count = Arc::clone(&state_count);
+            let max_depth = Arc::clone(&max_depth);
             let generated = Arc::clone(&generated);
             let discoveries = Arc::clone(&discoveries);
             handles.push(std::thread::spawn(move || {
@@ -127,6 +130,7 @@ where M: Model + Send + Sync + 'static,
                         &*visitor,
                         1500,
                         target_max_depth,
+                        &max_depth,
                         symmetry,
                     );
                     if discoveries.len() == property_count {
@@ -168,6 +172,7 @@ where M: Model + Send + Sync + 'static,
             handles,
             job_market,
             state_count,
+            max_depth,
             generated,
             discoveries,
         }
@@ -184,10 +189,12 @@ where M: Model + Send + Sync + 'static,
         visitor: &Option<Box<dyn CheckerVisitor<M> + Send + Sync>>,
         mut max_count: usize,
         target_max_depth: Option<NonZeroUsize>,
+        global_max_depth: &AtomicUsize,
         symmetry: Option<fn(&M::State) -> M::State>,
     ) {
         let properties = model.properties();
 
+        let mut current_max_depth = global_max_depth.load(Ordering::Relaxed);
         let mut actions = Vec::new();
         loop {
             // Done if reached max count.
@@ -199,6 +206,11 @@ where M: Model + Send + Sync + 'static,
                 None => return,
                 Some(pair) => pair,
             };
+
+            if max_depth.get() > current_max_depth {
+                let _ = global_max_depth.compare_exchange(current_max_depth, max_depth.get(), Ordering::Relaxed, Ordering::Relaxed);
+                current_max_depth = max_depth.get();
+            }
 
             if let Some(target_max_depth) = target_max_depth {
                 if max_depth >= target_max_depth {
@@ -331,6 +343,10 @@ where M: Model,
     }
 
     fn unique_state_count(&self) -> usize { self.generated.len() }
+
+    fn max_depth(&self) -> usize {
+        self.max_depth.load(Ordering::Relaxed)
+    }
 
     fn discoveries(&self) -> HashMap<&'static str, Path<M::State, M::Action>> {
         self.discoveries.iter()

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -18,6 +18,7 @@ struct StatusView {
     model: String,
     state_count: usize,
     unique_state_count: usize,
+    max_depth: usize,
     properties: Vec<Property>,
     recent_path: Option<String>,
 }
@@ -150,6 +151,7 @@ where M: Model,
         done: checker.is_done(),
         state_count: checker.state_count(),
         unique_state_count: checker.unique_state_count(),
+        max_depth: checker.max_depth(),
         properties: get_properties(checker),
         recent_path: snapshot.read().1.as_ref().map(|p| format!("{:?}", p)),
     };
@@ -166,7 +168,7 @@ where M: Model,
     checker.run_to_completion();
 }
 
-fn get_properties<C, M>(checker: &Arc<C>) -> Vec<Property> 
+fn get_properties<C, M>(checker: &Arc<C>) -> Vec<Property>
 where M: Model,
       M::State: Hash,
       C: Checker<M>,
@@ -348,11 +350,11 @@ mod test {
                         ]),
                     }),
                     properties: vec![
-                        (Expectation::Always, "delta within 1".to_owned(), None), 
-                        (Expectation::Sometimes, "can reach max".to_owned(), None), 
-                        (Expectation::Eventually, "must reach max".to_owned(), None), 
-                        (Expectation::Eventually, "must exceed max".to_owned(), None), 
-                        (Expectation::Always, "#in <= #out".to_owned(), None), 
+                        (Expectation::Always, "delta within 1".to_owned(), None),
+                        (Expectation::Sometimes, "can reach max".to_owned(), None),
+                        (Expectation::Eventually, "must reach max".to_owned(), None),
+                        (Expectation::Eventually, "must exceed max".to_owned(), None),
+                        (Expectation::Always, "#in <= #out".to_owned(), None),
                         (Expectation::Eventually, "#out <= #in + 1".to_owned(), None)
                     ],
                     svg: Some("<svg version=\'1.1\' baseProfile=\'full\' width=\'500\' height=\'30\' viewbox=\'-20 -20 520 50\' xmlns=\'http://www.w3.org/2000/svg\'><defs><marker class=\'svg-event-shape\' id=\'arrow\' markerWidth=\'12\' markerHeight=\'10\' refX=\'12\' refY=\'5\' orient=\'auto\'><polygon points=\'0 0, 12 5, 0 10\' /></marker></defs><line x1=\'0\' y1=\'0\' x2=\'0\' y2=\'30\' class=\'svg-actor-timeline\' />\n<text x=\'0\' y=\'0\' class=\'svg-actor-label\'>0</text>\n<line x1=\'100\' y1=\'0\' x2=\'100\' y2=\'30\' class=\'svg-actor-timeline\' />\n<text x=\'100\' y=\'0\' class=\'svg-actor-label\'>1</text>\n</svg>\n".to_string()),
@@ -387,11 +389,11 @@ mod test {
                     network: Network::new_unordered_nonduplicating([]),
                 }),
                 properties: vec![
-                    (Expectation::Always, "delta within 1".to_owned(), None), 
-                    (Expectation::Sometimes, "can reach max".to_owned(), None), 
-                    (Expectation::Eventually, "must reach max".to_owned(), None), 
-                    (Expectation::Eventually, "must exceed max".to_owned(), None), 
-                    (Expectation::Always, "#in <= #out".to_owned(), None), 
+                    (Expectation::Always, "delta within 1".to_owned(), None),
+                    (Expectation::Sometimes, "can reach max".to_owned(), None),
+                    (Expectation::Eventually, "must reach max".to_owned(), None),
+                    (Expectation::Eventually, "must exceed max".to_owned(), None),
+                    (Expectation::Always, "#in <= #out".to_owned(), None),
                     (Expectation::Eventually, "#out <= #in + 1".to_owned(), None)
                 ],
                 svg: Some("<svg version='1.1' baseProfile='full' width='500' height='60' viewbox='-20 -20 520 80' xmlns='http://www.w3.org/2000/svg'><defs><marker class='svg-event-shape' id='arrow' markerWidth='12' markerHeight='10' refX='12' refY='5' orient='auto'><polygon points='0 0, 12 5, 0 10' /></marker></defs><line x1='0' y1='0' x2='0' y2='60' class='svg-actor-timeline' />\n<text x='0' y='0' class='svg-actor-label'>0</text>\n<line x1='100' y1='0' x2='100' y2='60' class='svg-actor-timeline' />\n<text x='100' y='0' class='svg-actor-label'>1</text>\n</svg>\n".to_string()),
@@ -413,11 +415,11 @@ mod test {
                     ]),
                 }),
                 properties: vec![
-                    (Expectation::Always, "delta within 1".to_owned(), None), 
-                    (Expectation::Sometimes, "can reach max".to_owned(), None), 
-                    (Expectation::Eventually, "must reach max".to_owned(), None), 
-                    (Expectation::Eventually, "must exceed max".to_owned(), None), 
-                    (Expectation::Always, "#in <= #out".to_owned(), None), 
+                    (Expectation::Always, "delta within 1".to_owned(), None),
+                    (Expectation::Sometimes, "can reach max".to_owned(), None),
+                    (Expectation::Eventually, "must reach max".to_owned(), None),
+                    (Expectation::Eventually, "must exceed max".to_owned(), None),
+                    (Expectation::Always, "#in <= #out".to_owned(), None),
                     (Expectation::Eventually, "#out <= #in + 1".to_owned(), None)
                 ],
                 svg: Some("<svg version='1.1' baseProfile='full' width='500' height='60' viewbox='-20 -20 520 80' xmlns='http://www.w3.org/2000/svg'><defs><marker class='svg-event-shape' id='arrow' markerWidth='12' markerHeight='10' refX='12' refY='5' orient='auto'><polygon points='0 0, 12 5, 0 10' /></marker></defs><line x1='0' y1='0' x2='0' y2='60' class='svg-actor-timeline' />\n<text x='0' y='0' class='svg-actor-label'>0</text>\n<line x1='100' y1='0' x2='100' y2='60' class='svg-actor-timeline' />\n<text x='100' y='0' class='svg-actor-label'>1</text>\n<line x1='0' x2='100' y1='0' y2='30' marker-end='url(#arrow)' class='svg-event-line' />\n<text x='100' y='30' class='svg-event-label'>Ping(0)</text>\n</svg>\n".to_string()),
@@ -448,6 +450,7 @@ mod test {
                  stateright::actor::actor_test_util::ping_pong::PingPongCfg, (u32, u32)>");
         assert_eq!(status.state_count, 5);
         assert_eq!(status.unique_state_count, 5);
+        assert_eq!(status.max_depth, 5);
         let assert_discovery =
             |status: &StatusView,
              expectation: Expectation,

--- a/src/report.rs
+++ b/src/report.rs
@@ -11,6 +11,8 @@ pub struct ReportData {
     pub total_states: usize,
     /// The number of unique states found.
     pub unique_states: usize,
+    /// Maximum depth explored.
+    pub max_depth: usize,
     /// The current duration checking has been running for.
     pub duration: Duration,
     /// Whether checking is done.
@@ -59,16 +61,17 @@ where
         if data.done {
             let _ = writeln!(
                 self.writer,
-                "Done. states={}, unique={}, sec={}",
+                "Done. states={}, unique={}, depth={}, sec={}",
                 data.total_states,
                 data.unique_states,
-                data.duration.as_secs()
+                data.max_depth,
+                data.duration.as_secs(),
             );
         } else {
             let _ = writeln!(
                 self.writer,
-                "Checking. states={}, unique={}",
-                data.total_states, data.unique_states
+                "Checking. states={}, unique={}, depth={}",
+                data.total_states, data.unique_states, data.max_depth
             );
         }
     }

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,9 +1,10 @@
 /// Represents the checker status. Reloads periodically until checking completes.
-function Status({done, state_count, unique_state_count, model, properties, recent_path}) {
+function Status({done, state_count, unique_state_count, max_depth, model, properties, recent_path}) {
     let status = this;
 
     status.stateCount = state_count.toLocaleString();
     status.uniqueStateCount = unique_state_count.toLocaleString();
+    status.maxDepth = max_depth.toLocaleString();
     status.model = model.replace(/[0-9A-Za-z_]+::/g, '');
     status.progress = 'Done';
     if (!done) {
@@ -19,6 +20,7 @@ Status.LOADING = new Status({
     done: 'loading...',
     state_count: 'loading...',
     unique_state_count: 'loading...',
+    max_depth: 'loading...',
     model: 'loading...',
     properties: [],
     recent_path: 'loading...',

--- a/ui/index.htm
+++ b/ui/index.htm
@@ -37,6 +37,10 @@
                     <span data-bind="text: uniqueStateCount">UNIQUE STATE COUNT</span>
                 </li>
                 <li>
+                    <label>Max Depth:</label>
+                    <span data-bind="text: maxDepth">MAX DEPTH</span>
+                </li>
+                <li>
                     <label>Progress:</label>
                     <span data-bind="text: progress,
                                      attr: {title: 'Recent path: ' + recentPath}">PROGRESS</span>


### PR DESCRIPTION
This introduces a new `CheckerBuilder::target_max_depth` function that enables users to limit the depth of the searches. This is implemented for the DFS and BFS checkers, but currently not the `on_demand` checker as that is not run eagerly anyway.

This also introduces a new report field `max_depth` that tracks the maximum depth explored. This is implemented for all checkers.

I'm happy for feedback on performance improvements / impacts of these and any improvements.

Fixes #36, Fixes #37