### PR TITLE
Named timers

### DIFF
--- a/examples/linearizable-register.rs
+++ b/examples/linearizable-register.rs
@@ -57,6 +57,7 @@ pub struct AbdActor {
 impl Actor for AbdActor {
     type Msg = RegisterMsg<RequestId, Value, AbdMsg>;
     type State = AbdState;
+    type Timer = ();
 
     fn on_start(&self, id: Id, _o: &mut Out<Self>) -> Self::State {
         AbdState {

--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -97,6 +97,7 @@ struct PaxosActor { peer_ids: Vec<Id> }
 impl Actor for PaxosActor {
     type Msg = RegisterMsg<RequestId, Value, PaxosMsg>;
     type State = PaxosState;
+    type Timer = ();
 
     fn on_start(&self, _id: Id, _o: &mut Out<Self>) -> Self::State {
         PaxosState {

--- a/examples/single-copy-register.rs
+++ b/examples/single-copy-register.rs
@@ -19,6 +19,7 @@ struct SingleCopyActor;
 impl Actor for SingleCopyActor {
     type Msg = RegisterMsg<RequestId, Value, ()>;
     type State = Value;
+    type Timer = ();
 
     fn on_start(&self, _id: Id, _o: &mut Out<Self>) -> Self::State {
         Value::default()

--- a/examples/timers.rs
+++ b/examples/timers.rs
@@ -1,0 +1,172 @@
+use serde::{Deserialize, Serialize};
+use stateright::report::WriteReporter;
+use stateright::actor::model_timeout;
+use stateright::{Model, Checker};
+use stateright::actor::{
+    Actor, ActorModel, Id, model_peers, Network,Out};
+use std::borrow::Cow;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Serialize, Deserialize)]
+enum PingerMsg {
+    Ping,
+    Pong,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Serialize, Deserialize)]
+enum PingerTimer {
+    Even,
+    Odd,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct PingerState {
+    received: usize
+}
+
+#[derive(Clone)]
+struct PingerActor { peer_ids: Vec<Id> }
+
+impl Actor for PingerActor {
+    type Msg = PingerMsg;
+    type State = PingerState;
+    type Timer = PingerTimer;
+
+    fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
+        o.set_timer(PingerTimer::Even, model_timeout());
+        o.set_timer(PingerTimer::Odd, model_timeout());
+        PingerState { received: 0 }
+    }
+
+    fn on_msg(&self, _id: Id, state: &mut Cow<Self::State>, src: Id, msg: Self::Msg, o: &mut Out<Self>) {
+        match msg {
+            PingerMsg::Ping => {
+                state.to_mut().received += 2;
+                o.send(src, PingerMsg::Pong);
+            }
+            PingerMsg::Pong => {
+                state.to_mut().received += 1;
+            }
+        }
+    }
+
+    fn on_timeout(&self, _id: Id, _state: &mut Cow<Self::State>, timer: &Self::Timer, o: &mut Out<Self>) {
+        match timer {
+            PingerTimer::Even => {
+                o.set_timer(PingerTimer::Even, model_timeout());
+                for &dst in &self.peer_ids {
+                    if usize::from(dst) % 2 == 0 {
+                        o.send(dst, PingerMsg::Ping);
+                    }
+                }
+            }
+            PingerTimer::Odd => {
+                o.set_timer(PingerTimer::Odd, model_timeout());
+                for &dst in &self.peer_ids {
+                    if usize::from(dst) % 2 != 0 {
+                        o.send(dst, PingerMsg::Ping);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PingerModelCfg {
+    server_count: usize,
+    network: Network<<PingerActor as Actor>::Msg>,
+}
+
+impl PingerModelCfg {
+    fn into_model(self) ->
+        ActorModel<
+            PingerActor,
+            Self,
+            ()>
+    {
+        ActorModel::new(
+                self.clone(),
+                (),
+            )
+            .actors((0..self.server_count)
+                .map(|i| PingerActor {
+                    peer_ids: model_peers(i, self.server_count),
+                }))
+            .init_network(self.network)
+    }
+}
+
+fn main() -> Result<(), pico_args::Error> {
+    env_logger::init_from_env(env_logger::Env::default()
+        .default_filter_or("info")); // `RUST_LOG=${LEVEL}` env variable to override
+
+    let mut args = pico_args::Arguments::from_env();
+    match args.subcommand()?.as_deref() {
+        Some("check") => {
+            let network = args.opt_free_from_str()?
+                .unwrap_or(Network::new_unordered_nonduplicating([]))
+                .into();
+            println!("Model checking Pingers");
+            PingerModelCfg {
+                    server_count: 3,
+                    network,
+                }
+                .into_model().checker().threads(num_cpus::get())
+                .spawn_dfs().report(&mut WriteReporter::new(&mut std::io::stdout()));
+        }
+        Some("explore") => {
+            let address = args.opt_free_from_str()?
+                .unwrap_or("localhost:3000".to_string());
+            let network = args.opt_free_from_str()?
+                .unwrap_or(Network::new_unordered_nonduplicating([]))
+                .into();
+            println!(
+                "Exploring state space for Pingers on {}.",
+                address);
+            PingerModelCfg {
+                    server_count: 3,
+                    network,
+                }
+                .into_model().checker().threads(num_cpus::get())
+                .serve(address);
+        }
+        // Some("spawn") => {
+        //     let port = 3000;
+        //
+        //     println!("  A set of servers that implement Single Decree Paxos.");
+        //     println!("  You can monitor and interact using tcpdump and netcat.");
+        //     println!("  Use `tcpdump -D` if you see error `lo0: No such device exists`.");
+        //     println!("Examples:");
+        //     println!("$ sudo tcpdump -i lo0 -s 0 -nnX");
+        //     println!("$ nc -u localhost {}", port);
+        //     println!("{}", serde_json::to_string(&RegisterMsg::Put::<RequestId, Value, ()>(1, 'X')).unwrap());
+        //     println!("{}", serde_json::to_string(&RegisterMsg::Get::<RequestId, Value, ()>(2)).unwrap());
+        //     println!();
+        //
+        //     // WARNING: Omits `ordered_reliable_link` to keep the message
+        //     //          protocol simple for `nc`.
+        //     let id0 = Id::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port + 0));
+        //     let id1 = Id::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port + 1));
+        //     let id2 = Id::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port + 2));
+        //     spawn(
+        //         serde_json::to_vec,
+        //         |bytes| serde_json::from_slice(bytes),
+        //         vec![
+        //             (id0, PingerActor { peer_ids: vec![id1, id2] }),
+        //             (id1, PingerActor { peer_ids: vec![id0, id2] }),
+        //             (id2, PingerActor { peer_ids: vec![id0, id1] }),
+        //         ]).unwrap();
+        // }
+        _ => {
+            println!("USAGE:");
+            // println!("  ./paxos check [CLIENT_COUNT] [NETWORK]");
+            println!("  ./timers explore [CLIENT_COUNT] [ADDRESS] [NETWORK]");
+            // println!("  ./paxos spawn");
+            println!("NETWORK: {}", Network::<<PingerActor as Actor>::Msg>::names().join(" | "));
+        }
+    }
+
+    Ok(())
+}

--- a/examples/timers.rs
+++ b/examples/timers.rs
@@ -1,32 +1,33 @@
 use serde::{Deserialize, Serialize};
-use stateright::report::WriteReporter;
 use stateright::actor::model_timeout;
-use stateright::{Model, Checker};
-use stateright::actor::{
-    Actor, ActorModel, Id, model_peers, Network,Out};
+use stateright::actor::{model_peers, Actor, ActorModel, Id, Network, Out};
+use stateright::report::WriteReporter;
+use stateright::{Checker, Model};
 use std::borrow::Cow;
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 enum PingerMsg {
     Ping,
     Pong,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 enum PingerTimer {
     Even,
     Odd,
+    NoOp,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct PingerState {
-    received: usize
+    sent: usize,
+    received: usize,
 }
 
 #[derive(Clone)]
-struct PingerActor { peer_ids: Vec<Id> }
+struct PingerActor {
+    peer_ids: Vec<Id>,
+}
 
 impl Actor for PingerActor {
     type Msg = PingerMsg;
@@ -36,13 +37,23 @@ impl Actor for PingerActor {
     fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
         o.set_timer(PingerTimer::Even, model_timeout());
         o.set_timer(PingerTimer::Odd, model_timeout());
-        PingerState { received: 0 }
+        o.set_timer(PingerTimer::NoOp, model_timeout());
+        PingerState {
+            sent: 0,
+            received: 0,
+        }
     }
 
-    fn on_msg(&self, _id: Id, state: &mut Cow<Self::State>, src: Id, msg: Self::Msg, o: &mut Out<Self>) {
+    fn on_msg(
+        &self,
+        _id: Id,
+        state: &mut Cow<Self::State>,
+        src: Id,
+        msg: Self::Msg,
+        o: &mut Out<Self>,
+    ) {
         match msg {
             PingerMsg::Ping => {
-                state.to_mut().received += 2;
                 o.send(src, PingerMsg::Pong);
             }
             PingerMsg::Pong => {
@@ -51,12 +62,19 @@ impl Actor for PingerActor {
         }
     }
 
-    fn on_timeout(&self, _id: Id, _state: &mut Cow<Self::State>, timer: &Self::Timer, o: &mut Out<Self>) {
+    fn on_timeout(
+        &self,
+        _id: Id,
+        state: &mut Cow<Self::State>,
+        timer: &Self::Timer,
+        o: &mut Out<Self>,
+    ) {
         match timer {
             PingerTimer::Even => {
                 o.set_timer(PingerTimer::Even, model_timeout());
                 for &dst in &self.peer_ids {
                     if usize::from(dst) % 2 == 0 {
+                        state.to_mut().sent += 1;
                         o.send(dst, PingerMsg::Ping);
                     }
                 }
@@ -65,9 +83,13 @@ impl Actor for PingerActor {
                 o.set_timer(PingerTimer::Odd, model_timeout());
                 for &dst in &self.peer_ids {
                     if usize::from(dst) % 2 != 0 {
+                        state.to_mut().sent += 1;
                         o.send(dst, PingerMsg::Ping);
                     }
                 }
+            }
+            PingerTimer::NoOp => {
+                o.set_timer(PingerTimer::NoOp, model_timeout());
             }
         }
     }
@@ -80,57 +102,54 @@ struct PingerModelCfg {
 }
 
 impl PingerModelCfg {
-    fn into_model(self) ->
-        ActorModel<
-            PingerActor,
-            Self,
-            ()>
-    {
-        ActorModel::new(
-                self.clone(),
-                (),
-            )
-            .actors((0..self.server_count)
-                .map(|i| PingerActor {
-                    peer_ids: model_peers(i, self.server_count),
-                }))
+    fn into_model(self) -> ActorModel<PingerActor, Self, ()> {
+        ActorModel::new(self.clone(), ())
+            .actors((0..self.server_count).map(|i| PingerActor {
+                peer_ids: model_peers(i, self.server_count),
+            }))
             .init_network(self.network)
+            .property(stateright::Expectation::Always, "true", |_, _| true)
     }
 }
 
 fn main() -> Result<(), pico_args::Error> {
-    env_logger::init_from_env(env_logger::Env::default()
-        .default_filter_or("info")); // `RUST_LOG=${LEVEL}` env variable to override
+    env_logger::init_from_env(env_logger::Env::default().default_filter_or("info")); // `RUST_LOG=${LEVEL}` env variable to override
 
     let mut args = pico_args::Arguments::from_env();
     match args.subcommand()?.as_deref() {
         Some("check") => {
-            let network = args.opt_free_from_str()?
+            let network = args
+                .opt_free_from_str()?
                 .unwrap_or(Network::new_unordered_nonduplicating([]))
                 .into();
             println!("Model checking Pingers");
             PingerModelCfg {
-                    server_count: 3,
-                    network,
-                }
-                .into_model().checker().threads(num_cpus::get())
-                .spawn_dfs().report(&mut WriteReporter::new(&mut std::io::stdout()));
+                server_count: 3,
+                network,
+            }
+            .into_model()
+            .checker()
+            .threads(num_cpus::get())
+            .spawn_dfs()
+            .report(&mut WriteReporter::new(&mut std::io::stdout()));
         }
         Some("explore") => {
-            let address = args.opt_free_from_str()?
+            let address = args
+                .opt_free_from_str()?
                 .unwrap_or("localhost:3000".to_string());
-            let network = args.opt_free_from_str()?
+            let network = args
+                .opt_free_from_str()?
                 .unwrap_or(Network::new_unordered_nonduplicating([]))
                 .into();
-            println!(
-                "Exploring state space for Pingers on {}.",
-                address);
+            println!("Exploring state space for Pingers on {}.", address);
             PingerModelCfg {
-                    server_count: 3,
-                    network,
-                }
-                .into_model().checker().threads(num_cpus::get())
-                .serve(address);
+                server_count: 3,
+                network,
+            }
+            .into_model()
+            .checker()
+            .threads(num_cpus::get())
+            .serve(address);
         }
         // Some("spawn") => {
         //     let port = 3000;
@@ -164,7 +183,10 @@ fn main() -> Result<(), pico_args::Error> {
             // println!("  ./paxos check [CLIENT_COUNT] [NETWORK]");
             println!("  ./timers explore [CLIENT_COUNT] [ADDRESS] [NETWORK]");
             // println!("  ./paxos spawn");
-            println!("NETWORK: {}", Network::<<PingerActor as Actor>::Msg>::names().join(" | "));
+            println!(
+                "NETWORK: {}",
+                Network::<<PingerActor as Actor>::Msg>::names().join(" | ")
+            );
         }
     }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -268,7 +268,7 @@ pub trait Actor: Sized {
     /// #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     /// enum MyActorTimer { Event1, Event2 }
     /// ```
-    type Timer: Clone + Debug + Eq + Hash + serde::Serialize;
+    type Timer: Clone + Debug + Eq + Hash;
 
     /// The type of state maintained by the actor.
     ///

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -242,6 +242,15 @@ pub fn is_no_op<A: Actor>(state: &Cow<A::State>, out: &Out<A>) -> bool {
     matches!(state, Cow::Borrowed(_)) && out.0.is_empty()
 }
 
+/// If true, then the actor did not update its state or output commands, besides renewing the same
+/// timer.
+#[allow(clippy::ptr_arg)] // `&Cow` needed for `matches!`
+pub fn is_no_op_with_timer<A: Actor>(state: &Cow<A::State>, out: &Out<A>, timer: &A::Timer) -> bool {
+    let keep_timer = out.iter().any(|c| matches!(c, Command::SetTimer(t, _) if t == timer));
+    let unmodified_out = out.0.is_empty() || (out.0.len() == 1 && keep_timer);
+    matches!(state, Cow::Borrowed(_)) && unmodified_out
+}
+
 /// An actor initializes internal state optionally emitting [outputs]; then it waits for incoming
 /// events, responding by updating its internal state and optionally emitting [outputs].
 ///

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -247,7 +247,7 @@ pub fn is_no_op<A: Actor>(state: &Cow<A::State>, out: &Out<A>) -> bool {
 #[allow(clippy::ptr_arg)] // `&Cow` needed for `matches!`
 pub fn is_no_op_with_timer<A: Actor>(state: &Cow<A::State>, out: &Out<A>, timer: &A::Timer) -> bool {
     let keep_timer = out.iter().any(|c| matches!(c, Command::SetTimer(t, _) if t == timer));
-    let unmodified_out = out.0.is_empty() || (out.0.len() == 1 && keep_timer);
+    let unmodified_out = out.0.len() == 1 && keep_timer;
     matches!(state, Cow::Borrowed(_)) && unmodified_out
 }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -30,6 +30,7 @@
 //! impl Actor for LogicalClockActor {
 //!     type Msg = MsgWithTimestamp;
 //!     type State = Timestamp;
+//!     type Timer = ();
 //!
 //!     fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
 //!         // The actor either bootstraps or starts at time zero.
@@ -84,6 +85,7 @@ use choice::{Choice, Never};
 mod model;
 mod model_state;
 mod network;
+mod timers;
 mod spawn;
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
@@ -97,6 +99,7 @@ pub mod actor_test_util;
 pub use model::*;
 pub use model_state::*;
 pub use network::*;
+pub use timers::*;
 pub mod ordered_reliable_link;
 pub mod register;
 pub mod write_once_register;
@@ -154,17 +157,17 @@ impl From<usize> for Id {
 
 /// Commands with which an actor can respond.
 #[derive(Debug, serde::Serialize)]
-pub enum Command<Msg> {
+pub enum Command<Msg, Timer> {
     /// Cancel the timer if one is set.
-    CancelTimer,
+    CancelTimer(Timer),
     /// Set/reset the timer.
-    SetTimer(Range<Duration>),
+    SetTimer(Timer, Range<Duration>),
     /// Send a message to a destination.
     Send(Id, Msg),
 }
 
 /// Holds [`Command`]s output by an actor.
-pub struct Out<A: Actor>(Vec<Command<A::Msg>>);
+pub struct Out<A: Actor>(Vec<Command<A::Msg, A::Timer>>);
 
 impl<A: Actor> Out<A> {
     /// Constructs an empty `Out`.
@@ -175,19 +178,19 @@ impl<A: Actor> Out<A> {
     /// Moves all [`Command`]s of `other` into `Self`, leaving `other` empty.
     pub fn append<B>(&mut self, other: &mut Out<B>)
     where
-        B: Actor<Msg = A::Msg>,
+        B: Actor<Msg = A::Msg, Timer = A::Timer>,
     {
         self.0.append(&mut other.0)
     }
 
     /// Records the need to set the timer. See [`Actor::on_timeout`].
-    pub fn set_timer(&mut self, duration: Range<Duration>) {
-        self.0.push(Command::SetTimer(duration));
+    pub fn set_timer(&mut self, tag: A::Timer, duration: Range<Duration>) {
+        self.0.push(Command::SetTimer(tag, duration));
     }
 
     /// Records the need to cancel the timer.
-    pub fn cancel_timer(&mut self) {
-        self.0.push(Command::CancelTimer);
+    pub fn cancel_timer(&mut self, tag: A::Timer) {
+        self.0.push(Command::CancelTimer(tag));
     }
 
     /// Records the need to send a message. See [`Actor::on_msg`].
@@ -213,21 +216,21 @@ impl<A: Actor> Debug for Out<A> {
 }
 
 impl<A: Actor> std::ops::Deref for Out<A> {
-    type Target = [Command<A::Msg>];
+    type Target = [Command<A::Msg, A::Timer>];
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
 
-impl<A: Actor> std::iter::FromIterator<Command<A::Msg>> for Out<A> {
-    fn from_iter<I: IntoIterator<Item = Command<A::Msg>>>(iter: I) -> Self {
+impl<A: Actor> std::iter::FromIterator<Command<A::Msg, A::Timer>> for Out<A> {
+    fn from_iter<I: IntoIterator<Item = Command<A::Msg, A::Timer>>>(iter: I) -> Self {
         Out(Vec::from_iter(iter))
     }
 }
 
 impl<A: Actor> IntoIterator for Out<A> {
-    type Item = Command<A::Msg>;
-    type IntoIter = std::vec::IntoIter<Command<A::Msg>>;
+    type Item = Command<A::Msg, A::Timer>;
+    type IntoIter = std::vec::IntoIter<Command<A::Msg, A::Timer>>;
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
@@ -255,6 +258,17 @@ pub trait Actor: Sized {
     /// enum MyActorMsg { Msg1(u64), Msg2(char) }
     /// ```
     type Msg: Clone + Debug + Eq + Hash;
+
+    /// The type for tagging timers.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use serde::{Deserialize, Serialize};
+    /// #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    /// enum MyActorTimer { Event1, Event2 }
+    /// ```
+    type Timer: Clone + Debug + Eq + Hash + serde::Serialize;
 
     /// The type of state maintained by the actor.
     ///
@@ -287,7 +301,7 @@ pub trait Actor: Sized {
     }
 
     /// Indicates the next state and commands when a timeout is encountered. See [`Out::set_timer`].
-    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, o: &mut Out<Self>) {
+    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, _timer: &Self::Timer, o: &mut Out<Self>) {
         // no-op by default
         let _ = id;
         let _ = state;
@@ -301,6 +315,7 @@ where
 {
     type Msg = A::Msg;
     type State = Choice<A::State, Never>;
+    type Timer = A::Timer;
 
     fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {
         let actor = self.get();
@@ -330,11 +345,11 @@ where
         }
     }
 
-    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, o: &mut Out<Self>) {
+    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, timer: &Self::Timer, o: &mut Out<Self>) {
         let actor = self.get();
         let mut state_prime = Cow::Borrowed(state.get());
         let mut o_prime = Out::new();
-        actor.on_timeout(id, &mut state_prime, &mut o_prime);
+        actor.on_timeout(id, &mut state_prime, timer, &mut o_prime);
 
         o.append(&mut o_prime);
         if let Cow::Owned(state_prime) = state_prime {
@@ -343,14 +358,16 @@ where
     }
 }
 
-impl<Msg, A1, A2> Actor for Choice<A1, A2>
+impl<Msg, Timer, A1, A2> Actor for Choice<A1, A2>
 where
     Msg: Clone + Debug + Eq + Hash,
-    A1: Actor<Msg = Msg>,
-    A2: Actor<Msg = Msg>,
+    Timer: Clone + Debug + Eq + Hash + serde::Serialize,
+    A1: Actor<Msg = Msg, Timer = Timer>,
+    A2: Actor<Msg = Msg, Timer = Timer>,
 {
     type Msg = Msg;
     type State = Choice<A1::State, A2::State>;
+    type Timer = Timer;
 
     fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {
         match self {
@@ -400,12 +417,12 @@ where
         }
     }
 
-    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, o: &mut Out<Self>) {
+    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, tag: &Self::Timer, o: &mut Out<Self>) {
         match (self, &**state) {
             (Choice::L(actor), Choice::L(state_prime)) => {
                 let mut state_prime = Cow::Borrowed(state_prime);
                 let mut o_prime = Out::new();
-                actor.on_timeout(id, &mut state_prime, &mut o_prime);
+                actor.on_timeout(id, &mut state_prime, tag, &mut o_prime);
                 o.append(&mut o_prime);
                 if let Cow::Owned(state_prime) = state_prime {
                     *state = Cow::Owned(Choice::L(state_prime));
@@ -414,7 +431,7 @@ where
             (Choice::R(actor), Choice::R(state_prime)) => {
                 let mut state_prime = Cow::Borrowed(state_prime);
                 let mut o_prime = Out::new();
-                actor.on_timeout(id, &mut state_prime, &mut o_prime);
+                actor.on_timeout(id, &mut state_prime, tag, &mut o_prime);
                 o.append(&mut o_prime);
                 if let Cow::Owned(state_prime) = state_prime {
                     *state = Cow::Owned(Choice::R(state_prime));
@@ -431,6 +448,7 @@ where
 impl Actor for () {
     type State = ();
     type Msg = ();
+    type Timer = ();
     fn on_start(&self, _: Id, _o: &mut Out<Self>) -> Self::State {}
     fn on_msg(&self, _: Id, _: &mut Cow<Self::State>, _: Id, _: Self::Msg, _: &mut Out<Self>) {}
 }
@@ -443,6 +461,7 @@ where
 {
     type Msg = Msg;
     type State = usize;
+    type Timer = ();
 
     fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
         if let Some((dst, msg)) = self.get(0) {

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -184,13 +184,13 @@ impl<A: Actor> Out<A> {
     }
 
     /// Records the need to set the timer. See [`Actor::on_timeout`].
-    pub fn set_timer(&mut self, tag: A::Timer, duration: Range<Duration>) {
-        self.0.push(Command::SetTimer(tag, duration));
+    pub fn set_timer(&mut self, timer: A::Timer, duration: Range<Duration>) {
+        self.0.push(Command::SetTimer(timer, duration));
     }
 
     /// Records the need to cancel the timer.
-    pub fn cancel_timer(&mut self, tag: A::Timer) {
-        self.0.push(Command::CancelTimer(tag));
+    pub fn cancel_timer(&mut self, timer: A::Timer) {
+        self.0.push(Command::CancelTimer(timer));
     }
 
     /// Records the need to send a message. See [`Actor::on_msg`].
@@ -417,12 +417,12 @@ where
         }
     }
 
-    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, tag: &Self::Timer, o: &mut Out<Self>) {
+    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, timer: &Self::Timer, o: &mut Out<Self>) {
         match (self, &**state) {
             (Choice::L(actor), Choice::L(state_prime)) => {
                 let mut state_prime = Cow::Borrowed(state_prime);
                 let mut o_prime = Out::new();
-                actor.on_timeout(id, &mut state_prime, tag, &mut o_prime);
+                actor.on_timeout(id, &mut state_prime, timer, &mut o_prime);
                 o.append(&mut o_prime);
                 if let Cow::Owned(state_prime) = state_prime {
                     *state = Cow::Owned(Choice::L(state_prime));
@@ -431,7 +431,7 @@ where
             (Choice::R(actor), Choice::R(state_prime)) => {
                 let mut state_prime = Cow::Borrowed(state_prime);
                 let mut o_prime = Out::new();
-                actor.on_timeout(id, &mut state_prime, tag, &mut o_prime);
+                actor.on_timeout(id, &mut state_prime, timer, &mut o_prime);
                 o.append(&mut o_prime);
                 if let Cow::Owned(state_prime) = state_prime {
                     *state = Cow::Owned(Choice::R(state_prime));

--- a/src/actor/actor_test_util.rs
+++ b/src/actor/actor_test_util.rs
@@ -13,6 +13,7 @@ pub mod ping_pong {
     impl Actor for PingPongActor {
         type Msg = PingPongMsg;
         type State = u32; // count
+        type Timer = ();
 
         fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
             if let Some(id) = self.serve_to {

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -9,7 +9,7 @@ use crate::actor::{
     is_no_op,
     Id,
     Network,
-    Out,
+    Out, is_no_op_with_timer,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -294,8 +294,7 @@ where A: Actor,
                 let mut state = Cow::Borrowed(&*last_sys_state.actor_states[index]);
                 let mut out = Out::new();
                 self.actors[index].on_timeout(id, &mut state, &timer, &mut out);
-                let keep_timer = out.iter().any(|c| matches!(c, Command::SetTimer(t, _) if t == &timer));
-                if is_no_op(&state, &out) && keep_timer { return None }
+                if is_no_op_with_timer(&state, &out, &timer) { return None }
                 let mut next_sys_state = last_sys_state.clone();
 
                 // Timer is no longer valid.

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -157,7 +157,7 @@ where A: Actor,
         self
     }
 
-    // Updates the actor state, sends messages, and configures the timer.
+    /// Updates the actor state, sends messages, and configures the timers.
     fn process_commands(&self, id: Id, commands: Out<A>, state: &mut ActorModelState<A, H>) {
         let index = usize::from(id);
         for c in commands {
@@ -294,8 +294,7 @@ where A: Actor,
                 let mut state = Cow::Borrowed(&*last_sys_state.actor_states[index]);
                 let mut out = Out::new();
                 self.actors[index].on_timeout(id, &mut state, &timer, &mut out);
-                let keep_timer = out.iter().any(|c| matches!(c, Command::SetTimer(_, _)));
-                if is_no_op(&state, &out) && keep_timer { return None }
+                if is_no_op(&state, &out) { return None }
                 let mut next_sys_state = last_sys_state.clone();
 
                 // Timer is no longer valid.

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -294,7 +294,8 @@ where A: Actor,
                 let mut state = Cow::Borrowed(&*last_sys_state.actor_states[index]);
                 let mut out = Out::new();
                 self.actors[index].on_timeout(id, &mut state, &timer, &mut out);
-                if is_no_op(&state, &out) { return None }
+                let keep_timer = out.iter().any(|c| matches!(c, Command::SetTimer(t, _) if t == &timer));
+                if is_no_op(&state, &out) && keep_timer { return None }
                 let mut next_sys_state = last_sys_state.clone();
 
                 // Timer is no longer valid.

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -177,10 +177,10 @@ where A: Actor,
                     if state.timers_set.len() <= index {
                         state.timers_set.resize_with(index + 1, Timers::new);
                     }
-                    state.timers_set[index].insert(timer);
+                    state.timers_set[index].set(timer);
                 },
                 Command::CancelTimer(timer) => {
-                    state.timers_set[index].remove(&timer);
+                    state.timers_set[index].cancel(&timer);
                 },
             }
         }
@@ -298,7 +298,7 @@ where A: Actor,
                 let mut next_sys_state = last_sys_state.clone();
 
                 // Timer is no longer valid.
-                next_sys_state.timers_set[index].remove(&timer);
+                next_sys_state.timers_set[index].cancel(&timer);
 
                 if let Cow::Owned(next_actor_state) = state {
                     next_sys_state.actor_states[index] = Arc::new(next_actor_state);

--- a/src/actor/model_state.rs
+++ b/src/actor/model_state.rs
@@ -20,6 +20,7 @@ impl<A, H> serde::Serialize for ActorModelState<A, H>
 where A: Actor,
       A::State: serde::Serialize,
       A::Msg: serde::Serialize,
+      A::Timer: serde::Serialize,
       H: serde::Serialize,
 {
     fn serialize<Ser: serde::Serializer>(&self, ser: Ser) -> Result<Ser::Ok, Ser::Error> {

--- a/src/actor/model_state.rs
+++ b/src/actor/model_state.rs
@@ -131,7 +131,7 @@ mod test {
     fn can_find_representative_from_equivalence_class() {
         let empty_timers = Timers::new();
         let mut non_empty_timers = Timers::new();
-        non_empty_timers.insert(());
+        non_empty_timers.set(());
         let state = ActorModelState::<A, History> {
             actor_states: vec![
                 Arc::new(ActorState { acks: vec![Id::from(1), Id::from(2)]}),

--- a/src/actor/register.rs
+++ b/src/actor/register.rs
@@ -123,6 +123,7 @@ where
 {
     type Msg = RegisterMsg<u64, char, InternalMsg>;
     type State = RegisterActorState<ServerActor::State, u64>;
+    type Timer = ServerActor::Timer;
 
     #[allow(clippy::identity_op)]
     fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {
@@ -215,7 +216,7 @@ where
         }
     }
 
-    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, o: &mut Out<Self>) {
+    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, timer: &Self::Timer, o: &mut Out<Self>) {
         use RegisterActor as A;
         use RegisterActorState as S;
         match (self, &**state) {
@@ -229,7 +230,7 @@ where
             ) => {
                 let mut server_state = Cow::Borrowed(server_state);
                 let mut server_out = Out::new();
-                server_actor.on_timeout(id, &mut server_state, &mut server_out);
+                server_actor.on_timeout(id, &mut server_state, timer, &mut server_out);
                 if let Cow::Owned(server_state) = server_state {
                     *state = Cow::Owned(RegisterActorState::Server(server_state))
                 }

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -2,6 +2,7 @@
 
 use crate::actor::*;
 use crossbeam_utils::thread;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
 use std::time::{Duration, Instant};
@@ -79,60 +80,62 @@ where
             s.spawn(move |_| {
                 let socket = UdpSocket::bind(addr).unwrap(); // panic if unable to bind
                 let mut in_buf = [0; 65_535];
-                let mut next_interrupt = practically_never();
+                let mut next_interrupts = HashMap::new();
 
                 let mut out = Out::new();
                 let mut state = Cow::Owned(actor.on_start(id, &mut out));
                 log::info!("Actor started. id={}, state={:?}, out={:?}", addr, state, out);
                 for c in out {
-                    on_command::<A, E>(addr, c, serialize, &socket, &mut next_interrupt);
+                    on_command::<A, E>(addr, c, serialize, &socket, &mut next_interrupts);
                 }
 
                 loop {
                     // Apply an interrupt if present, otherwise wait for a message.
                     let mut out = Out::new();
-                    if let Some(max_wait) = next_interrupt.checked_duration_since(Instant::now()) {
-                        socket.set_read_timeout(Some(max_wait)).expect("set_read_timeout failed");
-                        match socket.recv_from(&mut in_buf) {
-                            Err(e) => {
-                                // Timeout (`WouldBlock`) ignored since next iteration will apply interrupt.
-                                if e.kind() != std::io::ErrorKind::WouldBlock {
-                                    log::warn!("Unable to read socket. Ignoring. id={}, err={:?}", addr, e);
-                                }
-                                continue;
-                            },
-                            Ok((count, src_addr)) => {
-                                match deserialize(&in_buf[..count]) {
-                                    Ok(msg) => {
-                                        if let SocketAddr::V4(src_addr) = src_addr {
-                                            log::info!("Received message. id={}, src={}, msg={}",
-                                                        addr, src_addr, format!("{:?}", msg));
-                                            actor.on_msg(id, &mut state, Id::from(src_addr), msg, &mut out);
-                                        } else {
-                                            log::debug!("Received non-IPv4 message. Ignoring. id={}, src={}, msg={}",
-                                                       addr, src_addr, format!("{:?}", msg));
+                    if let Some((min_timer, min_instant)) = next_interrupts.iter().min_by_key(|(_, instant)| *instant).map(|(t, i)| (t.clone(), i.clone())) {
+                        if let Some(max_wait) = min_instant.checked_duration_since(Instant::now()) {
+                            socket.set_read_timeout(Some(max_wait)).expect("set_read_timeout failed");
+                            match socket.recv_from(&mut in_buf) {
+                                Err(e) => {
+                                    // Timeout (`WouldBlock`) ignored since next iteration will apply interrupt.
+                                    if e.kind() != std::io::ErrorKind::WouldBlock {
+                                        log::warn!("Unable to read socket. Ignoring. id={}, err={:?}", addr, e);
+                                    }
+                                    continue;
+                                },
+                                Ok((count, src_addr)) => {
+                                    match deserialize(&in_buf[..count]) {
+                                        Ok(msg) => {
+                                            if let SocketAddr::V4(src_addr) = src_addr {
+                                                log::info!("Received message. id={}, src={}, msg={}",
+                                                            addr, src_addr, format!("{:?}", msg));
+                                                actor.on_msg(id, &mut state, Id::from(src_addr), msg, &mut out);
+                                            } else {
+                                                log::debug!("Received non-IPv4 message. Ignoring. id={}, src={}, msg={}",
+                                                           addr, src_addr, format!("{:?}", msg));
+                                                continue;
+                                            }
+                                        },
+                                        Err(e) => {
+                                            log::debug!("Unable to parse message. Ignoring. id={}, src={}, buf={:?}, err={:?}",
+                                                       addr, src_addr, &in_buf[..count], e);
                                             continue;
                                         }
-                                    },
-                                    Err(e) => {
-                                        log::debug!("Unable to parse message. Ignoring. id={}, src={}, buf={:?}, err={:?}",
-                                                   addr, src_addr, &in_buf[..count], e);
-                                        continue;
                                     }
-                                }
-                            },
+                                },
+                            }
+                        } else {
+                            next_interrupts.remove(&min_timer); // timer is no longer valid
+                            actor.on_timeout(id, &mut state, &min_timer, &mut out);
                         }
-                    } else {
-                        next_interrupt = practically_never(); // timer is no longer valid
-                        actor.on_timeout(id, &mut state, &mut out);
-                    };
+                    }
 
                     // Handle commands and update state.
                     if !is_no_op(&state, &out) {
                         log::debug!("Acted. id={}, state={:?}, out={:?}",
                                     addr, state, out);
                     }
-                    for c in out { on_command::<A, E>(addr, c, serialize, &socket, &mut next_interrupt); }
+                    for c in out { on_command::<A, E>(addr, c, serialize, &socket, &mut next_interrupts); }
                 }
             });
         }
@@ -142,10 +145,10 @@ where
 /// The effect to perform in response to spawned actor outputs.
 fn on_command<A, E>(
     addr: SocketAddrV4,
-    command: Command<A::Msg>,
+    command: Command<A::Msg, A::Timer>,
     serialize: fn(&A::Msg) -> Result<Vec<u8>, E>,
     socket: &UdpSocket,
-    next_interrupt: &mut Instant)
+    next_interrupts: &mut HashMap<A::Timer, Instant>)
 where A: Actor,
       A::Msg: Debug,
       E: Debug,
@@ -166,7 +169,7 @@ where A: Actor,
                 },
             }
         },
-        Command::SetTimer(range) => {
+        Command::SetTimer(timer, range) => {
             let duration =
                 if range.start < range.end {
                     use rand::Rng;
@@ -174,10 +177,11 @@ where A: Actor,
                 } else {
                     range.start
                 };
-            *next_interrupt = Instant::now() + duration;
+            next_interrupts.entry(timer).and_modify(|d| *d = Instant::now() + duration).or_insert_with(|| Instant::now() + duration);
         },
-        Command::CancelTimer => {
-            *next_interrupt = practically_never();
+        Command::CancelTimer(timer) => {
+            // if not already set then that's fine to leave
+            next_interrupts.entry(timer).and_modify(|d| *d = practically_never());
         },
     }
 }

--- a/src/actor/timers.rs
+++ b/src/actor/timers.rs
@@ -1,0 +1,37 @@
+use crate::{util::HashableHashSet, Rewrite, RewritePlan};
+use std::hash::Hash;
+
+use super::Id;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize)]
+pub struct Timers<T: Hash + Eq>(HashableHashSet<T>);
+
+impl<T> Timers<T>
+where
+    T: Hash + Eq,
+{
+    pub fn new() -> Self {
+        Self(HashableHashSet::new())
+    }
+
+    pub fn insert(&mut self, timer: T) -> bool {
+        self.0.insert(timer)
+    }
+
+    pub fn remove(&mut self, timer: &T) -> bool {
+        self.0.remove(timer)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item=&T> {
+        self.0.iter()
+    }
+}
+
+impl<T> Rewrite<Id> for Timers<T>
+where
+    T: Eq + Hash + Clone ,
+{
+    fn rewrite<S>(&self, _plan: &RewritePlan<Id, S>) -> Self {
+        self.clone()
+    }
+}

--- a/src/actor/timers.rs
+++ b/src/actor/timers.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 
 use super::Id;
 
+/// A collection of timers that have been set for a given actor.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize)]
 pub struct Timers<T: Hash + Eq>(HashableHashSet<T>);
 
@@ -10,18 +11,22 @@ impl<T> Timers<T>
 where
     T: Hash + Eq,
 {
+    /// Create a new timer set.
     pub fn new() -> Self {
         Self(HashableHashSet::new())
     }
 
-    pub fn insert(&mut self, timer: T) -> bool {
+    /// Set a timer.
+    pub fn set(&mut self, timer: T) -> bool {
         self.0.insert(timer)
     }
 
-    pub fn remove(&mut self, timer: &T) -> bool {
+    /// Cancel a timer.
+    pub fn cancel(&mut self, timer: &T) -> bool {
         self.0.remove(timer)
     }
 
+    /// Iterate through the currently set timers.
     pub fn iter(&self) -> impl Iterator<Item=&T> {
         self.0.iter()
     }

--- a/src/actor/write_once_register.rs
+++ b/src/actor/write_once_register.rs
@@ -131,6 +131,7 @@ where
 {
     type Msg = WORegisterMsg<u64, char, InternalMsg>;
     type State = WORegisterActorState<ServerActor::State, u64>;
+    type Timer = ServerActor::Timer;
 
     #[allow(clippy::identity_op)]
     fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {
@@ -169,7 +170,7 @@ where
         }
     }
 
-    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, o: &mut Out<Self>) {
+    fn on_timeout(&self, id: Id, state: &mut Cow<Self::State>, timer: &Self::Timer, o: &mut Out<Self>) {
         use WORegisterActor as A;
         use WORegisterActorState as S;
         match (self, &**state) {
@@ -183,7 +184,7 @@ where
             ) => {
                 let mut server_state = Cow::Borrowed(server_state);
                 let mut server_out = Out::new();
-                server_actor.on_timeout(id, &mut server_state, &mut server_out);
+                server_actor.on_timeout(id, &mut server_state, timer, &mut server_out);
                 if let Cow::Owned(server_state) = server_state {
                     *state = Cow::Owned(WORegisterActorState::Server(server_state))
                 }
@@ -273,8 +274,8 @@ where ServerState : Rewrite<R> + Clone,
     fn rewrite<S>(&self, plan: &RewritePlan<R,S>) -> Self {
         match self {
             WORegisterActorState::Client{..} => { (*self).clone() }
-            WORegisterActorState::Server(server_state) => { 
-                WORegisterActorState::Server(server_state.rewrite(plan)) 
+            WORegisterActorState::Server(server_state) => {
+                WORegisterActorState::Server(server_state.rewrite(plan))
             }
         }
    }

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -278,6 +278,7 @@ where M: Model,
 mod test {
     use super::*;
     use crate::test_util::binary_clock::*;
+    use crate::actor::Timers;
     use lazy_static::lazy_static;
 
     #[test]
@@ -344,7 +345,7 @@ mod test {
                     state: Some(ActorModelState {
                         actor_states: vec![Arc::new(0), Arc::new(0)],
                         history: (0, 1),
-                        is_timer_set: vec![false,false],
+                        timers_set: vec![Timers::new(); 2],
                         network: Network::new_unordered_nonduplicating([
                             Envelope { src: Id::from(0), dst: Id::from(1), msg: Ping(0) },
                         ]),
@@ -367,7 +368,7 @@ mod test {
                 let fp = fingerprint(&ActorModelState::<PingPongActor, PingPongHistory> {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
-                    is_timer_set: vec![false,false],
+                    timers_set: vec![Timers::new(); 2],
                     network: Network::new_unordered_nonduplicating([
                         Envelope { src: Id::from(0), dst: Id::from(1), msg: Ping(0) },
                     ]),
@@ -385,7 +386,7 @@ mod test {
                 state: Some(ActorModelState {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
-                    is_timer_set: vec![false,false],
+                    timers_set: vec![Timers::new(); 2],
                     network: Network::new_unordered_nonduplicating([]),
                 }),
                 properties: vec![
@@ -409,7 +410,7 @@ mod test {
                         Arc::new(1),
                     ],
                     history: (1, 2),
-                    is_timer_set: vec![false,false],
+                    timers_set: vec![Timers::new(); 2],
                     network: Network::new_unordered_nonduplicating([
                         Envelope { src: Id::from(1), dst: Id::from(0), msg: Pong(0) },
                     ]),

--- a/src/checker/rewrite.rs
+++ b/src/checker/rewrite.rs
@@ -85,7 +85,7 @@ impl<R, V> Rewrite<R> for HashableHashSet<V> where V: Eq + Hash + Rewrite<R> {
         self.iter().map(|x| x.rewrite(plan)).collect()
     }
 }
-impl<R, K, V> Rewrite<R> for HashableHashMap<K,V> 
+impl<R, K, V> Rewrite<R> for HashableHashMap<K,V>
 where V: Eq + Hash + Rewrite<R>,
       K: Eq + Hash + Rewrite<R>,
       {

--- a/src/checker/rewrite_plan.rs
+++ b/src/checker/rewrite_plan.rs
@@ -19,7 +19,7 @@ use std::fmt;
 pub struct RewritePlan<R,S> {s: S, f: fn(&R, &S) -> R}
 
 impl<R,S> RewritePlan<R,S> {
-    /// Applies the rewrite plan to a value of type R 
+    /// Applies the rewrite plan to a value of type R
     pub fn rewrite(&self, x : &R) -> R {
         (self.f)(x, &self.s)
     }
@@ -45,7 +45,7 @@ where S: fmt::Debug
     }
 }
 
-impl<R, V> From<DenseNatMap<R, V>> for RewritePlan<R,DenseNatMap<R,R>> 
+impl<R, V> From<DenseNatMap<R, V>> for RewritePlan<R,DenseNatMap<R,R>>
 where R: From<usize> + Copy,
       usize: From<R>,
       V: Ord,
@@ -55,7 +55,7 @@ where R: From<usize> + Copy,
     }
 }
 
-impl<R, V> From<&DenseNatMap<R, V>> for RewritePlan<R,DenseNatMap<R,R>> 
+impl<R, V> From<&DenseNatMap<R, V>> for RewritePlan<R,DenseNatMap<R,R>>
 where R: From<usize> + Copy,
       usize: From<R>,
       V: Ord,


### PR DESCRIPTION
Adds a `Timer` type to the `Actor` trait.
This is used for triggering different behaviours on timeout, e.g. timeouts of different peers as well as timeouts for different functionality.

It changes the timers storage from `Vec<bool>` to a `Vec<Timers>` where `Timers` is effectively a hash set.

Fixes #41 