### PR TITLE
Report and join

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -333,7 +333,8 @@ pub trait Checker<M: Model> {
                         duration: method_start.elapsed(),
                         done: false,
                     });
-                    std::thread::sleep(std::time::Duration::from_millis(1_000));
+                    let delay = reporter_mutex.lock().unwrap().delay();
+                    std::thread::sleep(delay);
                 }
             });
 
@@ -385,7 +386,8 @@ pub trait Checker<M: Model> {
                 duration: method_start.elapsed(),
                 done: false,
             });
-            std::thread::sleep(std::time::Duration::from_millis(1_000));
+            let delay = reporter.delay();
+            std::thread::sleep(delay);
         }
         reporter.report_checking(ReportData {
             total_states: self.state_count(),

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -12,7 +12,7 @@ mod visitor;
 
 use crate::report::{ReportData, ReportDiscovery, Reporter};
 use crate::{Expectation, Model, Fingerprint};
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::num::NonZeroUsize;
@@ -322,7 +322,7 @@ pub trait Checker<M: Model> {
         });
 
         // Finish with a discovery summary.
-        let mut discoveries = HashMap::new();
+        let mut discoveries = BTreeMap::new();
         for (name, path) in self.discoveries() {
             let discovery = ReportDiscovery {
                 path,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -284,6 +284,9 @@ pub trait Checker<M: Model> {
     /// [`is_done`]: Self::is_done
     fn join(self) -> Self;
 
+    /// Extract the thread handles from this checker.
+    fn handles(&mut self) -> Vec<JoinHandle<()>>;
+
     /// Indicates that either all properties have associated discoveries or all reachable states
     /// have been visited.
     fn is_done(&self) -> bool;

--- a/src/checker/bfs.rs
+++ b/src/checker/bfs.rs
@@ -334,13 +334,6 @@ where M: Model,
             .collect()
     }
 
-    fn join(mut self) -> Self {
-        for h in self.handles.drain(0..) {
-            h.join().unwrap();
-        }
-        self
-    }
-
     fn handles(&mut self) -> Vec<JoinHandle<()>>{
         std::mem::take(&mut self.handles)
     }

--- a/src/checker/bfs.rs
+++ b/src/checker/bfs.rs
@@ -11,6 +11,7 @@ use std::hash::{BuildHasherDefault, Hash};
 use std::sync::Arc;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::JoinHandle;
 
 // While this file is currently quite similar to dfs.rs, a refactoring to lift shared
 // behavior is being postponed until DPOR is implemented.
@@ -338,6 +339,10 @@ where M: Model,
             h.join().unwrap();
         }
         self
+    }
+
+    fn handles(&mut self) -> Vec<JoinHandle<()>>{
+        std::mem::take(&mut self.handles)
     }
 
     fn is_done(&self) -> bool {

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -10,6 +10,7 @@ use std::hash::{BuildHasherDefault, Hash};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::JoinHandle;
 
 // While this file is currently quite similar to bfs.rs, a refactoring to lift shared
 // behavior is being postponed until DPOR is implemented.
@@ -368,6 +369,10 @@ where M: Model,
             h.join().unwrap();
         }
         self
+    }
+
+    fn handles(&mut self) -> Vec<JoinHandle<()>>{
+        std::mem::take(&mut self.handles)
     }
 
     fn is_done(&self) -> bool {

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -364,13 +364,6 @@ where M: Model,
             .collect()
     }
 
-    fn join(mut self) -> Self {
-        for h in self.handles.drain(0..) {
-            h.join().unwrap();
-        }
-        self
-    }
-
     fn handles(&mut self) -> Vec<JoinHandle<()>>{
         std::mem::take(&mut self.handles)
     }

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -13,6 +13,7 @@ use std::hash::{BuildHasherDefault, Hash};
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::thread::JoinHandle;
 
 // While this file is currently quite similar to dfs.rs, a refactoring to lift shared
 // behavior is being postponed until DPOR is implemented.
@@ -488,6 +489,10 @@ where
             h.join().unwrap();
         }
         self
+    }
+
+    fn handles(&mut self) -> Vec<JoinHandle<()>>{
+        std::mem::take(&mut self.handles)
     }
 
     fn is_done(&self) -> bool {

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -484,13 +484,6 @@ where
             .collect()
     }
 
-    fn join(mut self) -> Self {
-        for h in self.handles.drain(0..) {
-            h.join().unwrap();
-        }
-        self
-    }
-
     fn handles(&mut self) -> Vec<JoinHandle<()>>{
         std::mem::take(&mut self.handles)
     }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::io::Write;
 use std::time::Duration;
@@ -36,7 +36,7 @@ pub trait Reporter<M: Model> {
     fn report_checking(&mut self, data: ReportData);
 
     /// Report the discoveries at the end of the checking run.
-    fn report_discoveries(&mut self, discoveries: HashMap<&'static str, ReportDiscovery<M>>)
+    fn report_discoveries(&mut self, discoveries: BTreeMap<&'static str, ReportDiscovery<M>>)
     where
         M::Action: Debug,
         M::State: Debug;
@@ -76,7 +76,7 @@ where
         }
     }
 
-    fn report_discoveries(&mut self, discoveries: HashMap<&'static str, ReportDiscovery<M>>)
+    fn report_discoveries(&mut self, discoveries: BTreeMap<&'static str, ReportDiscovery<M>>)
     where
         M::Action: Debug,
         M::State: Debug,

--- a/src/report.rs
+++ b/src/report.rs
@@ -40,6 +40,10 @@ pub trait Reporter<M: Model> {
     where
         M::Action: Debug,
         M::State: Debug;
+
+    fn delay(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(1_000)
+    }
 }
 
 pub struct WriteReporter<'a, W> {


### PR DESCRIPTION
This introduces a new method on the checker trait for waiting for the completion of the checker (joining threads) as well as reporting. This reduces the artifact that done times can report after a delay from the actual finish.

I'm mainly wanting this for use in iterative DFS, its nice to start from a max depth of 1 but the first few depths lead to a group of sleeps which would be nice to avoid at least in the reported finish time.

I think further work would be interesting to effectively invert the reporting, sending report data events every time a checker pulls something off the job market or loops on its local set, that should bring the actual runtime down (no need to sleep).

Fixes #43 