### PR TITLE
Implement crash failures

### DIFF
--- a/src/actor/model_state.rs
+++ b/src/actor/model_state.rs
@@ -13,6 +13,7 @@ pub struct ActorModelState<A: Actor, H = ()> {
     pub actor_states: Vec<Arc<A::State>>,
     pub network: Network<A::Msg>,
     pub timers_set: Vec<Timers<A::Timer>>,
+    pub crashed: Vec<bool>,
     pub history: H,
 }
 
@@ -48,6 +49,7 @@ where
             history: self.history.clone(),
             timers_set: self.timers_set.clone(),
             network: self.network.clone(),
+            crashed: self.crashed.clone(),
         }
     }
 }
@@ -123,6 +125,7 @@ where
             actor_states: plan.reindex(&self.actor_states),
             network: self.network.rewrite(&plan),
             timers_set: plan.reindex(&self.timers_set),
+            crashed: plan.reindex(&self.crashed),
             history: self.history.rewrite(&plan),
         }
     }
@@ -160,6 +163,7 @@ mod test {
                 Envelope { src: 1.into(), dst: 2.into(), msg: "Ack(Y)" },
             ]),
             timers_set: vec![non_empty_timers.clone(), empty_timers.clone(), non_empty_timers.clone()],
+            crashed: vec![false; 3],
             history: History {
                 send_sequence: vec![
                     // Id(0) sends two writes
@@ -197,6 +201,7 @@ mod test {
                 Envelope { src: 0.into(), dst: 1.into(), msg: "Ack(Y)" },
             ]),
             timers_set: vec![empty_timers, non_empty_timers.clone(), non_empty_timers.clone()],
+            crashed: vec![false; 3],
             history: History {
                 send_sequence: vec![
                     // Id(2) sends two writes

--- a/src/actor/timers.rs
+++ b/src/actor/timers.rs
@@ -32,6 +32,11 @@ where
         self.0.remove(timer)
     }
 
+    /// Cancels all timers.
+    pub fn cancel_all(&mut self) {
+        self.0.clear();
+    }
+
     /// Iterate through the currently set timers.
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.0.iter()

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -414,6 +414,7 @@ mod test {
                         actor_states: vec![Arc::new(0), Arc::new(0)],
                         history: (0, 1),
                         timers_set: vec![Timers::new(); 2],
+                        crashed: vec![false; 2],
                         network: Network::new_unordered_nonduplicating([
                             Envelope { src: Id::from(0), dst: Id::from(1), msg: Ping(0) },
                         ]),
@@ -437,6 +438,7 @@ mod test {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
                     timers_set: vec![Timers::new(); 2],
+                    crashed: vec![false; 2],
                     network: Network::new_unordered_nonduplicating([Envelope {
                         src: Id::from(0),
                         dst: Id::from(1),
@@ -457,6 +459,7 @@ mod test {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
                     timers_set: vec![Timers::new(); 2],
+                    crashed: vec![false; 2],
                     network: Network::new_unordered_nonduplicating([]),
                 }),
                 properties: vec![
@@ -481,6 +484,7 @@ mod test {
                     ],
                     history: (1, 2),
                     timers_set: vec![Timers::new(); 2],
+                    crashed: vec![false; 2],
                     network: Network::new_unordered_nonduplicating([
                         Envelope { src: Id::from(1), dst: Id::from(0), msg: Pong(0) },
                     ]),


### PR DESCRIPTION
It is now possible for actors to crash.
If the model checker decides to crash an actor, it cancels all timers the actor has set, but it does not remove from the network any message addressed to it, so that in a future implementation it will be possible for the model checker to recover the actor and deliver such messages to it. (This would correspond to an actor recovering "soon enough").
The user can specify the maximum number of actors that can be contemporarily crashed. For example, the Raft consensus algorithm can tolerate _f_ contemporarily crashed servers with 2 _f_ + 1 servers.