### PR TITLE
Add `Clone` constraint for `Model::Action` and simplify next_steps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ pub trait Model: Sized {
     type State;
 
     /// The type of action that transitions between states.
-    type Action;
+    type Action: Clone;
 
     /// Returns the initial possible states.
     fn init_states(&self) -> Vec<Self::State>;
@@ -194,17 +194,13 @@ pub trait Model: Sized {
 
     /// Indicates the steps (action-state pairs) that follow a particular state.
     fn next_steps(&self, last_state: &Self::State) -> Vec<(Self::Action, Self::State)> {
-        // Must generate the actions twice because they are consumed by `next_state`.
-        let mut actions1 = Vec::new();
-        let mut actions2 = Vec::new();
-        self.actions(last_state, &mut actions1);
-        self.actions(last_state, &mut actions2);
-        actions1
+        let mut actions = Vec::new();
+        self.actions(last_state, &mut actions);
+        actions
             .into_iter()
-            .zip(actions2)
-            .filter_map(|(action1, action2)| {
-                self.next_state(last_state, action1)
-                    .map(|state| (action2, state))
+            .filter_map(|action| {
+                self.next_state(last_state, action.clone())
+                    .map(|state| (action, state))
             })
             .collect()
     }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -121,7 +121,7 @@ pub mod dgraph {
 pub mod function {
     use crate::*;
 
-    impl<T> Model for fn(Option<&T>, &mut Vec<T>) {
+    impl<T: Clone> Model for fn(Option<&T>, &mut Vec<T>) {
         type State = T;
         type Action = T;
         fn init_states(&self) -> Vec<Self::State> {


### PR DESCRIPTION
Instead of calling `Module::actions` twice in `Module::next_steps`, it is better to clone the result directly. Because `Model::actions` can sometimes be expensive.