### PR TITLE
Add name function to actor trait

### DIFF
--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -112,6 +112,10 @@ impl Actor for PaxosActor {
     type State = PaxosState;
     type Timer = ();
 
+    fn name(&self) -> String {
+        "Paxos Server".to_owned()
+    }
+
     fn on_start(&self, _id: Id, _o: &mut Out<Self>) -> Self::State {
         PaxosState {
             // shared state

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -42,7 +42,11 @@ where
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ActorModelAction<Msg, Timer> {
     /// A message can be delivered to an actor.
-    Deliver { src: Id, dst: Id, msg: Msg },
+    Deliver {
+        src: Id,
+        dst: Id,
+        msg: Msg,
+    },
     /// A message can be dropped if the network is lossy.
     Drop(Envelope<Msg>),
     /// An actor can by notified after a timeout.
@@ -478,7 +482,14 @@ where
             .actors
             .iter()
             .enumerate()
-            .map(|(i, a)| format!("{} {}", i, a.name()))
+            .map(|(i, a)| {
+                let name = a.name();
+                if name.is_empty() {
+                    i.to_string()
+                } else {
+                    format!("{} {}", i, name)
+                }
+            })
             .collect::<Vec<_>>();
         let max_name_len = actor_names
             .iter()
@@ -799,7 +810,8 @@ mod test {
                 .spawn_bfs()
                 .join()
                 .unique_state_count(),
-            2); // initial and delivery of Interesting
+            2
+        ); // initial and delivery of Interesting
         assert_eq!(
             model
                 .clone()
@@ -808,7 +820,8 @@ mod test {
                 .spawn_bfs()
                 .join()
                 .unique_state_count(),
-            2); // initial and delivery of Interesting
+            2
+        ); // initial and delivery of Interesting
         assert_eq!(
             model
                 .clone()
@@ -817,7 +830,8 @@ mod test {
                 .spawn_bfs()
                 .join()
                 .unique_state_count(),
-            3); // initial, delivery of Uninteresting, and subsequent delivery of Interesting
+            3
+        ); // initial, delivery of Uninteresting, and subsequent delivery of Interesting
     }
 
     #[test]

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -473,7 +473,21 @@ where
     fn as_svg(&self, path: Path<Self::State, Self::Action>) -> Option<String> {
         use std::fmt::Write;
 
-        let plot = |x, y| (x as u64 * 100, y as u64 * 30);
+        let approximate_letter_width_px = 10;
+        let actor_names = self
+            .actors
+            .iter()
+            .enumerate()
+            .map(|(i, a)| format!("{} {}", i, a.name()))
+            .collect::<Vec<_>>();
+        let max_name_len = actor_names
+            .iter()
+            .map(|n| n.len() as u64)
+            .max()
+            .unwrap_or_default()
+            * approximate_letter_width_px;
+        let spacing = std::cmp::max(100, max_name_len);
+        let plot = |x, y| (x as u64 * spacing, y as u64 * 30);
         let actor_count = path.last_state().actor_states.len();
         let path = path.into_vec();
 
@@ -499,7 +513,7 @@ where
             </defs>").unwrap();
 
         // Vertical timeline for each actor.
-        for (actor_index, actor) in self.actors.iter().enumerate() {
+        for (actor_index, actor_name) in actor_names.iter().enumerate() {
             let (x1, y1) = plot(actor_index, 0);
             let (x2, y2) = plot(actor_index, path.len());
             writeln!(
@@ -510,8 +524,8 @@ where
             .unwrap();
             writeln!(
                 &mut svg,
-                "<text x='{}' y='{}' class='svg-actor-label'>{}{}</text>",
-                x1, y1, actor_index, actor.name()
+                "<text x='{}' y='{}' class='svg-actor-label'>{}</text>",
+                x1, y1, actor_name,
             )
             .unwrap();
         }

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -499,7 +499,7 @@ where
             </defs>").unwrap();
 
         // Vertical timeline for each actor.
-        for actor_index in 0..actor_count {
+        for (actor_index, actor) in self.actors.iter().enumerate() {
             let (x1, y1) = plot(actor_index, 0);
             let (x2, y2) = plot(actor_index, path.len());
             writeln!(
@@ -510,8 +510,8 @@ where
             .unwrap();
             writeln!(
                 &mut svg,
-                "<text x='{}' y='{}' class='svg-actor-label'>{:?}</text>",
-                x1, y1, actor_index
+                "<text x='{}' y='{}' class='svg-actor-label'>{}{}</text>",
+                x1, y1, actor_index, actor.name()
             )
             .unwrap();
         }

--- a/src/actor/ordered_reliable_link.rs
+++ b/src/actor/ordered_reliable_link.rs
@@ -173,6 +173,10 @@ where
             }
         }
     }
+
+    fn name(&self) -> String {
+        self.wrapped_actor.name()
+    }
 }
 
 fn process_output<A: Actor>(

--- a/src/actor/register.rs
+++ b/src/actor/register.rs
@@ -127,6 +127,23 @@ where
     type State = RegisterActorState<ServerActor::State, u64>;
     type Timer = ServerActor::Timer;
 
+    fn name(&self) -> String {
+        match self {
+            RegisterActor::Client {
+                put_count: _,
+                server_count: _,
+            } => "Client".to_owned(),
+            RegisterActor::Server(s) => {
+                let n = s.name();
+                if n.is_empty() {
+                    "Server".to_owned()
+                } else {
+                    n
+                }
+            }
+        }
+    }
+
     #[allow(clippy::identity_op)]
     fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {
         match self {

--- a/src/actor/write_once_register.rs
+++ b/src/actor/write_once_register.rs
@@ -284,6 +284,16 @@ where
             _ => {}
         }
     }
+
+    fn name(&self) -> String {
+        match self {
+            WORegisterActor::Client {
+                put_count: _,
+                server_count: _,
+            } => "Client".to_owned(),
+            WORegisterActor::Server(a) => a.name(),
+        }
+    }
 }
 
 impl<R, ServerState, RequestId> Rewrite<R> for WORegisterActorState<ServerState, RequestId>

--- a/ui/app.css
+++ b/ui/app.css
@@ -165,7 +165,7 @@ ul {
 }
 
 .svg-actor-label {
-    fill: var(--bg-med);
+    fill: var(--fg-lit);
 }
 .svg-actor-timeline {
     stroke: var(--bg-med);


### PR DESCRIPTION
This enables showing a useful name in the explorer next to the id, e.g. differentiating servers and clients more clearly.

I'd be happy with updating the `name` function's args if needed.