### PR TITLE
Refactor JobMarket and handle checker threads panicking

### DIFF
--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -1,13 +1,13 @@
 //! Private module for selective re-export.
 
 use crate::checker::{Checker, EventuallyBits, Expectation, Path};
+use crate::job_market::JobMarket;
 use crate::{
     fingerprint, CheckerBuilder, CheckerVisitor, ControlFlow, Fingerprint, Model, Property,
 };
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use nohash_hasher::NoHashHasher;
-use parking_lot::{Condvar, Mutex};
 use std::collections::{HashMap, VecDeque};
 use std::hash::{BuildHasherDefault, Hash};
 use std::num::NonZeroUsize;
@@ -21,11 +21,10 @@ use std::thread::JoinHandle;
 pub(crate) struct OnDemandChecker<M: Model> {
     // Immutable state.
     model: Arc<M>,
-    thread_count: usize,
     handles: Vec<std::thread::JoinHandle<()>>,
 
     // Mutable state.
-    job_market: Arc<Mutex<JobMarket<M::State>>>,
+    job_market: JobMarket<Job<M::State>>,
     state_count: Arc<AtomicUsize>,
     max_depth: Arc<AtomicUsize>,
     generated:
@@ -33,11 +32,7 @@ pub(crate) struct OnDemandChecker<M: Model> {
     discoveries: Arc<DashMap<&'static str, Fingerprint>>,
     control_flow: std::sync::mpsc::SyncSender<ControlFlow>,
 }
-struct JobMarket<State> {
-    wait_count: usize,
-    jobs: Vec<Job<State>>,
-}
-type Job<State> = VecDeque<(State, Fingerprint, EventuallyBits, NonZeroUsize)>;
+type Job<State> = (State, Fingerprint, EventuallyBits, NonZeroUsize);
 
 impl<M> OnDemandChecker<M>
 where
@@ -92,16 +87,12 @@ where
         let discoveries = Arc::new(DashMap::default());
         let mut handles = Vec::new();
 
-        let has_new_job = Arc::new(Condvar::new());
-        let job_market = Arc::new(Mutex::new(JobMarket {
-            wait_count: thread_count,
-            jobs: vec![pending],
-        }));
+        let mut job_market = JobMarket::new(thread_count);
+        job_market.push(pending);
         for t in 0..thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);
-            let has_new_job = Arc::clone(&has_new_job);
-            let job_market = Arc::clone(&job_market);
+            let mut job_market = job_market.clone();
             let state_count = Arc::clone(&state_count);
             let max_depth = Arc::clone(&max_depth);
             let generated = Arc::clone(&generated);
@@ -121,39 +112,17 @@ where
                         loop {
                             if pending.is_empty() {
                                 pending = {
-                                    let mut job_market = job_market.lock();
-                                    match job_market.jobs.pop() {
-                                        None => {
-                                            // Done if all are waiting.
-                                            if job_market.wait_count == thread_count {
-                                                log::debug!(
-                                                    "{}: No more work. Shutting down... gen={}",
-                                                    t,
-                                                    generated.len()
-                                                );
-                                                has_new_job.notify_all();
-                                                return;
-                                            }
-
-                                            // Otherwise more work may become available.
-                                            log::trace!(
-                                                "{}: No jobs. Awaiting. blocked={}",
-                                                t,
-                                                job_market.wait_count
-                                            );
-                                            has_new_job.wait(&mut job_market);
-                                            continue;
-                                        }
-                                        Some(job) => {
-                                            job_market.wait_count -= 1;
-                                            log::trace!(
-                                                "{}: Job found. size={}, blocked={}",
-                                                t,
-                                                job.len(),
-                                                job_market.wait_count
-                                            );
-                                            job
-                                        }
+                                    let jobs = job_market.pop();
+                                    if jobs.is_empty() {
+                                        log::debug!(
+                                            "{}: No more work. Shutting down... gen={}",
+                                            t,
+                                            generated.len()
+                                        );
+                                        return;
+                                    } else {
+                                        log::trace!("{}: Job found. size={}", t, jobs.len());
+                                        jobs
                                     }
                                 };
                                 log::debug!(
@@ -223,10 +192,6 @@ where
                                     t,
                                     generated.len()
                                 );
-                                let mut job_market = job_market.lock();
-                                job_market.wait_count += 1;
-                                drop(job_market);
-                                has_new_job.notify_all();
                                 return;
                             }
                             if let Some(target_state_count) = target_state_count {
@@ -242,27 +207,7 @@ where
 
                             // Step 2: Share work.
                             if pending.len() > 1 && thread_count > 1 {
-                                let mut job_market = job_market.lock();
-                                let pieces = 1 + std::cmp::min(
-                                    job_market.wait_count,
-                                    pending.len(),
-                                );
-                                let size = pending.len() / pieces;
-                                for _ in 1..pieces {
-                                    log::trace!(
-                                        "{}: Sharing work. blocked={}, size={}",
-                                        t,
-                                        job_market.wait_count,
-                                        size
-                                    );
-                                    job_market
-                                        .jobs
-                                        .push(pending.split_off(pending.len() - size));
-                                    has_new_job.notify_one();
-                                }
-                            } else if pending.is_empty() {
-                                let mut job_market = job_market.lock();
-                                job_market.wait_count += 1;
+                                job_market.split_and_push(&mut pending);
                             }
                         }
                     })
@@ -281,7 +226,6 @@ where
 
         OnDemandChecker {
             model,
-            thread_count,
             handles,
             job_market,
             state_count,
@@ -301,7 +245,7 @@ where
             Option<Fingerprint>,
             BuildHasherDefault<NoHashHasher<u64>>,
         >,
-        pending: &mut Job<M::State>,
+        pending: &mut VecDeque<Job<M::State>>,
         discoveries: &DashMap<&'static str, Fingerprint>,
         visitor: &Option<Box<dyn CheckerVisitor<M> + Send + Sync>>,
         max_count: usize,
@@ -497,9 +441,7 @@ where
     }
 
     fn is_done(&self) -> bool {
-        let job_market = self.job_market.lock();
-        job_market.jobs.is_empty() && job_market.wait_count == self.thread_count
-            || self.discoveries.len() == self.model.properties().len()
+        self.job_market.is_closed() || self.discoveries.len() == self.model.properties().len()
     }
 }
 

--- a/src/job_market.rs
+++ b/src/job_market.rs
@@ -137,7 +137,11 @@ impl<Job> JobMarket<Job> {
             market.open_count
         );
         for _ in 1..pieces {
-            market.jobs.push(jobs.split_off(jobs.len() - size));
+            let to_share = jobs.split_off(jobs.len() - size);
+            if to_share.is_empty() {
+                continue;
+            }
+            market.jobs.push(to_share);
             self.has_new_job.notify_one();
         }
     }

--- a/src/job_market.rs
+++ b/src/job_market.rs
@@ -1,0 +1,89 @@
+use parking_lot::{Condvar, Mutex};
+use std::{collections::VecDeque, sync::Arc};
+
+pub struct JobMarket<Job> {
+    has_new_job: Arc<Condvar>,
+    market: Arc<Mutex<JobMarketInner<Job>>>,
+}
+
+impl<Job> Clone for JobMarket<Job> {
+    fn clone(&self) -> Self {
+        Self {
+            has_new_job: Arc::clone(&self.has_new_job),
+            market: Arc::clone(&self.market),
+        }
+    }
+}
+
+impl<Job> Drop for JobMarket<Job> {
+    fn drop(&mut self) {
+        let mut market = self.market.lock();
+        market.open_count = market.open_count.saturating_sub(1);
+        self.has_new_job.notify_all();
+    }
+}
+
+struct JobMarketInner<Job> {
+    /// Number of markets working on jobs.
+    open_count: usize,
+    /// Jobs available.
+    jobs: Vec<VecDeque<Job>>,
+}
+
+impl<Job> JobMarket<Job> {
+    pub fn new(thread_count: usize) -> Self {
+        Self {
+            has_new_job: Arc::new(Condvar::new()),
+            market: Arc::new(Mutex::new(JobMarketInner {
+                open_count: thread_count,
+                jobs: Vec::new(),
+            })),
+        }
+    }
+
+    pub fn pop(&mut self) -> VecDeque<Job> {
+        let mut market = self.market.lock();
+        loop {
+            if let Some(job) = market.jobs.pop() {
+                log::trace!("Got jobs. Working.");
+                return job;
+            } else {
+                // Otherwise more work may become available.
+                market.open_count = market.open_count.saturating_sub(1);
+                if market.open_count == 0 {
+                    // we are the last running thread, notify all others and return so we can
+                    // shutdown properly
+                    log::trace!("No jobs. Last running thread.");
+                    self.has_new_job.notify_all();
+                    return VecDeque::new();
+                }
+                log::trace!("No jobs. Awaiting. running={}", market.open_count);
+                self.has_new_job.wait(&mut market);
+                market.open_count += 1;
+            }
+        }
+    }
+
+    pub fn push(&mut self, jobs: VecDeque<Job>) {
+        let mut market = self.market.lock();
+        market.jobs.push(jobs);
+        log::trace!("Pushing jobs. running={}", market.open_count);
+        self.has_new_job.notify_one();
+    }
+
+    pub fn split_and_push(&mut self, jobs: &mut VecDeque<Job>) {
+        let mut market = self.market.lock();
+        let pieces = 1 + std::cmp::min(market.open_count, jobs.len());
+        let size = jobs.len() / pieces;
+        for _ in 1..pieces {
+            log::trace!("Sharing work. size={} running={}", size, market.open_count);
+            market.jobs.push(jobs.split_off(jobs.len() - size));
+            self.has_new_job.notify_one();
+        }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        let market = self.market.lock();
+        market.jobs.is_empty() && market.open_count == 0
+    }
+}

--- a/src/job_market.rs
+++ b/src/job_market.rs
@@ -25,6 +25,7 @@ impl<Job> Drop for JobMarket<Job> {
     fn drop(&mut self) {
         let mut market = self.market.lock();
         market.open = false;
+        market.jobs.clear();
         market.open_count = market.open_count.saturating_sub(1);
         self.has_new_job.notify_all();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@
 #[warn(anonymous_parameters)]
 #[warn(missing_docs)]
 mod checker;
+mod job_market;
 pub mod report;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};


### PR DESCRIPTION
This extracts the `JobMarket` struct from the different checkers and provides a uniform API.
This ends up making the checkers a bit cleaner, and gets us some nicer behaviour in the job market.

Primarily this was needed in order to track when a thread has panicked. When one does:
1. the `drop` implementation is called for the `JobMarket`
2. This closes the market
3. More interactions with the `JobMarket` on other threads will eventually close the threads.

Closes #29 

Different design than described in #29 but I think it makes more sense to view the panic as a bug in the model code rather than a property violation and just stop the checking there.