### PR TITLE
Add checker timeout

### DIFF
--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -55,6 +55,7 @@ use stateright::semantics::LinearizabilityTester;
 use stateright::util::{HashableHashMap, HashableHashSet};
 use stateright::{Checker, Expectation, Model, UniformChooser};
 use std::borrow::Cow;
+use std::time::Duration;
 
 type Round = u32;
 type Ballot = (Round, Id);
@@ -414,6 +415,7 @@ fn main() -> Result<(), pico_args::Error> {
             .into_model()
             .checker()
             .threads(num_cpus::get())
+            .timeout(Duration::from_secs(10))
             .spawn_simulation(0, UniformChooser)
             .report(&mut WriteReporter::new(&mut std::io::stdout()));
         }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -19,7 +19,7 @@ use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Instant, Duration};
 
 pub use path::*;
 pub use representative::*;
@@ -69,6 +69,7 @@ pub struct CheckerBuilder<M: Model> {
     target_max_depth: Option<NonZeroUsize>,
     thread_count: usize,
     visitor: Option<Box<dyn CheckerVisitor<M> + Send + Sync>>,
+    timeout: Option<Duration>,
 }
 impl<M: Model> CheckerBuilder<M> {
     pub(crate) fn new(model: M) -> Self {
@@ -79,6 +80,7 @@ impl<M: Model> CheckerBuilder<M> {
             symmetry: None,
             thread_count: 1,
             visitor: None,
+            timeout: None,
         }
     }
 
@@ -261,6 +263,14 @@ impl<M: Model> CheckerBuilder<M> {
     pub fn visitor(self, visitor: impl CheckerVisitor<M> + Send + Sync + 'static) -> Self {
         Self {
             visitor: Some(Box::new(visitor)),
+            ..self
+        }
+    }
+
+    /// Set the timeout to limit the checker execution to.
+    pub fn timeout(self, duration: Duration) -> Self {
+        Self {
+            timeout: Some(duration),
             ..self
         }
     }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -19,7 +19,7 @@ use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 pub use path::*;
 pub use representative::*;

--- a/src/checker/bfs.rs
+++ b/src/checker/bfs.rs
@@ -82,9 +82,10 @@ where
         let discoveries = Arc::new(DashMap::default());
         let mut handles = Vec::new();
 
-        let mut job_broker = JobBroker::new(thread_count);
-        job_broker.push(pending);
         let close_at = options.timeout.map(|t| SystemTime::now() + t);
+        let mut job_broker = JobBroker::new(thread_count, close_at);
+        job_broker.push(pending);
+
         for t in 0..thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);

--- a/src/checker/bfs.rs
+++ b/src/checker/bfs.rs
@@ -12,6 +12,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
+use std::time::SystemTime;
 
 // While this file is currently quite similar to dfs.rs, a refactoring to lift shared
 // behavior is being postponed until DPOR is implemented.
@@ -83,6 +84,7 @@ where
 
         let mut job_broker = JobBroker::new(thread_count);
         job_broker.push(pending);
+        let close_at = options.timeout.map(|t| SystemTime::now() + t);
         for t in 0..thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -85,9 +85,10 @@ where
         let discoveries = Arc::new(DashMap::default());
         let mut handles = Vec::new();
 
-        let mut job_broker = JobBroker::new(thread_count);
-        job_broker.push(pending);
         let close_at = options.timeout.map(|t| SystemTime::now() + t);
+        let mut job_broker = JobBroker::new(thread_count, close_at);
+        job_broker.push(pending);
+
         for t in 0..thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -11,6 +11,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
+use std::time::SystemTime;
 
 // While this file is currently quite similar to bfs.rs, a refactoring to lift shared
 // behavior is being postponed until DPOR is implemented.
@@ -86,6 +87,7 @@ where
 
         let mut job_broker = JobBroker::new(thread_count);
         job_broker.push(pending);
+        let close_at = options.timeout.map(|t| SystemTime::now() + t);
         for t in 0..thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -88,10 +88,10 @@ where
         let discoveries = Arc::new(DashMap::default());
         let mut handles = Vec::new();
 
-        let mut job_broker = JobBroker::new(thread_count);
+        let close_at = options.timeout.map(|t| SystemTime::now() + t);
+        let mut job_broker = JobBroker::new(thread_count, close_at);
         job_broker.push(pending);
 
-        let close_at = options.timeout.map(|t| SystemTime::now() + t);
         for t in 0..thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -14,6 +14,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
+use std::time::SystemTime;
 
 // While this file is currently quite similar to dfs.rs, a refactoring to lift shared
 // behavior is being postponed until DPOR is implemented.
@@ -89,6 +90,8 @@ where
 
         let mut job_broker = JobBroker::new(thread_count);
         job_broker.push(pending);
+
+        let close_at = options.timeout.map(|t| SystemTime::now() + t);
         for t in 0..thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);

--- a/src/checker/simulation.rs
+++ b/src/checker/simulation.rs
@@ -9,9 +9,10 @@ use rand::SeedableRng;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::thread::JoinHandle;
+use std::thread::{sleep, JoinHandle};
+use std::time::{Duration, SystemTime};
 
 use super::EventuallyBits;
 
@@ -113,12 +114,33 @@ where
 
         let mut thread_seed = seed;
 
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let sd = Arc::clone(&shutdown);
+        if let Some(close_after) = options.timeout {
+            let closing_time = SystemTime::now() + close_after;
+            std::thread::Builder::new()
+                .name("timeout".to_owned())
+                .spawn(move || loop {
+                    let now = SystemTime::now();
+                    if closing_time < now {
+                        log::debug!("Reached timeout, triggering shutdown");
+                        sd.store(true, Ordering::Relaxed);
+                    }
+                    if sd.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    sleep(Duration::from_secs(1));
+                })
+                .unwrap();
+        }
+
         for t in 0..options.thread_count {
             let model = Arc::clone(&model);
             let visitor = Arc::clone(&visitor);
             let state_count = Arc::clone(&state_count);
             let max_depth = Arc::clone(&max_depth);
             let discoveries = Arc::clone(&discoveries);
+            let shutdown = Arc::clone(&shutdown);
             let chooser = chooser.clone();
             handles.push(
                 std::thread::Builder::new()
@@ -129,6 +151,11 @@ where
                         // FIXME: use a reproducible rng, one that will not change over versions.
                         let mut rng = StdRng::seed_from_u64(seed);
                         loop {
+                            if shutdown.load(Ordering::Relaxed) {
+                                log::debug!("{}: Got shutdown signal.", t);
+                                break;
+                            }
+
                             Self::check_trace_from_initial::<C>(
                                 &model,
                                 seed,

--- a/src/job_market.rs
+++ b/src/job_market.rs
@@ -54,7 +54,7 @@ struct JobMarket<Job> {
 impl<Job> JobBroker<Job>
 where
     Job: Send + 'static,
-    {
+{
     /// Create a new market for a group of threads.
     pub fn new(thread_count: usize, close_at: Option<SystemTime>) -> Self {
         let s = Self {


### PR DESCRIPTION
Fixes #69

- DFS and BFS checkers use the shared job market, so they rely on the timeout now implemented within that.
- Simulation checker does not use the job market, so relies on its own logic for timeout.

This has the benefit of doing a 'clean' shutdown for each checker type, clearing work to be done, rather than stopping them mid-flow.

This might be updated when the checkers get unified with DPOR #7 