### PR TITLE
fix: non-unique fingerprint in unordered duplicating network

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -618,6 +618,9 @@ mod test {
                 vec!['A', 'B', 'C'],
                 vec!['A', 'C', 'D'],
                 vec!['A', 'B', 'C', 'D'],
+                vec!['A', 'B', 'C', 'D'],
+                vec!['A', 'B', 'C', 'D'],
+                vec!['A', 'B', 'C', 'D'],
             ]
         );
     }


### PR DESCRIPTION
Fixes #73 by remembering the last envelop delivered in the network. 

In this way, the actor model can differentiate two actions taken next that does not change the actor state, so that the Web UI of explorer can work as expected by the user. 