### PR TITLE
Add `Actor::on_random` to model non-determinism

### DIFF
--- a/examples/interaction.rs
+++ b/examples/interaction.rs
@@ -102,6 +102,7 @@ impl Actor for Counter {
     type Msg = Msg;
     type State = CounterState;
     type Timer = InputTimer;
+    type Random = ();
 
     fn on_start(&self, _id: Id, _o: &mut Out<Self>) -> Self::State {
         self.initial_state
@@ -155,6 +156,7 @@ impl Actor for Client {
     type Msg = Msg;
     type State = InputState;
     type Timer = InputTimer;
+    type Random = ();
 
     fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
         // Set a timeout to trigger sending increment request.

--- a/examples/linearizable-register.rs
+++ b/examples/linearizable-register.rs
@@ -65,6 +65,7 @@ impl Actor for AbdActor {
     type Msg = RegisterMsg<RequestId, Value, AbdMsg>;
     type State = AbdState;
     type Timer = ();
+    type Random = ();
 
     fn on_start(&self, id: Id, _o: &mut Out<Self>) -> Self::State {
         AbdState {

--- a/examples/lww-register.rs
+++ b/examples/lww-register.rs
@@ -1,0 +1,257 @@
+use std::net::{Ipv4Addr, SocketAddrV4};
+
+use serde::{Deserialize, Serialize};
+use stateright::{
+    actor::{spawn, Actor, ActorModel, Id},
+    report::WriteReporter,
+    util::HashableHashMap,
+    CheckerBuilder, Model,
+};
+
+/// A Last Write Wins (LWW) register, implemented as a state-based CRDT.
+/// <https://www.bartoszsypytkowski.com/the-state-of-a-state-based-crdts/#lastwritewinsregister>.
+#[derive(Hash, PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+struct LwwRegister<T> {
+    value: T,
+    timestamp: u128,
+    updater_id: usize,
+}
+
+impl<T: Clone> LwwRegister<T> {
+    fn merge(a: &Self, b: &Self) -> Self {
+        if (a.timestamp,) > (b.timestamp,) {
+            a.clone()
+        } else {
+            b.clone()
+        }
+    }
+
+    fn set(&mut self, value: T, timestamp: u128, updater_id: usize) {
+        self.value = value;
+        self.timestamp = timestamp;
+        self.updater_id = updater_id;
+    }
+}
+
+#[derive(Hash, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+enum Value {
+    A,
+    B,
+    C,
+}
+
+#[derive(Hash, Debug, PartialEq, Eq, Clone)]
+enum LwwActorActions<T> {
+    SetValue(T),
+    SetTime(u128),
+}
+
+#[derive(Hash, Debug, PartialEq, Eq, Clone)]
+struct LwwActorState {
+    register: Option<LwwRegister<Value>>,
+    local_clock: u128,
+}
+
+impl LwwActorState {
+    fn new() -> Self {
+        Self {
+            register: None,
+            local_clock: 1000,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LwwActor {
+    peers: Vec<Id>,
+}
+
+impl LwwActor {
+    fn populate_choices(&self, o: &mut stateright::actor::Out<Self>, time: u128) {
+        o.choose_random(
+            "node_action",
+            vec![
+                LwwActorActions::SetValue(Value::A),
+                LwwActorActions::SetValue(Value::B),
+                LwwActorActions::SetValue(Value::C),
+                LwwActorActions::SetTime(time.saturating_add(1)),
+                LwwActorActions::SetTime(time.saturating_sub(1)),
+            ],
+        );
+    }
+}
+
+impl Actor for LwwActor {
+    type Msg = LwwRegister<Value>;
+    type Timer = ();
+    type State = LwwActorState;
+    type Random = LwwActorActions<Value>;
+
+    fn on_start(
+        &self,
+        _: stateright::actor::Id,
+        o: &mut stateright::actor::Out<Self>,
+    ) -> Self::State {
+        let state = LwwActorState::new();
+        self.populate_choices(o, state.local_clock);
+        state
+    }
+
+    fn on_random(
+        &self,
+        id: stateright::actor::Id,
+        state: &mut std::borrow::Cow<Self::State>,
+        random: &Self::Random,
+        o: &mut stateright::actor::Out<Self>,
+    ) {
+        match random {
+            LwwActorActions::SetValue(value) => {
+                let state_mut = state.to_mut();
+                if let Some(register) = &mut state_mut.register {
+                    register.set(value.clone(), state_mut.local_clock, usize::from(id));
+                } else {
+                    state_mut.register = Some(LwwRegister {
+                        value: value.clone(),
+                        timestamp: state_mut.local_clock,
+                        updater_id: usize::from(id),
+                    })
+                }
+                o.broadcast(
+                    self.peers.iter(),
+                    state_mut.register.as_ref().unwrap(),
+                );
+            }
+            LwwActorActions::SetTime(time) => {
+                state.to_mut().local_clock = *time;
+            }
+        }
+        self.populate_choices(o, state.local_clock)
+    }
+
+    fn on_msg(
+        &self,
+        _: Id,
+        state: &mut std::borrow::Cow<Self::State>,
+        _: Id,
+        msg: Self::Msg,
+        _: &mut stateright::actor::Out<Self>,
+    ) {
+        let state_mut = state.to_mut();
+        if let Some(register) = &mut state_mut.register {
+            let merged = LwwRegister::merge(register, &msg);
+            *register = merged;
+        } else {
+            state_mut.register = Some(msg.clone())
+        }
+    }
+}
+
+fn build_checker(num_actors: usize) -> CheckerBuilder<ActorModel<LwwActor>> {
+    let nodes: Vec<_> = (0..num_actors).map(Id::from).collect();
+    let mut checker_builder = ActorModel::new((), ());
+    for _ in 0..num_actors {
+        checker_builder = checker_builder.actor(LwwActor {
+            peers: nodes.clone(),
+        });
+    }
+    checker_builder
+        .init_network(stateright::actor::Network::UnorderedNonDuplicating(
+            HashableHashMap::new(),
+        ))
+        .property(
+            stateright::Expectation::Always,
+            "eventually consistent",
+            |_, state| {
+                // CRDT's "eventual consistency" means the states should be consistent if there are
+                // no more messages on the network. Unlike `Expectation::Eventually`, it doesn't
+                // count if the condition was transiently satisfied before reaching the terminal
+                // state.
+                if state.network.len() == 0 {
+                    let mut peekable_iter = state.actor_states.iter().peekable();
+                    while let (Some(s1), Some(s2)) = (peekable_iter.next(), peekable_iter.peek()) {
+                        if s1.register != s2.register {
+                            return false;
+                        }
+                    }
+                }
+                true
+            },
+        )
+        .checker()
+}
+
+pub fn main() -> Result<(), pico_args::Error> {
+    use stateright::Checker;
+
+    let mut args = pico_args::Arguments::from_env();
+    match args.subcommand()?.as_deref() {
+        Some("check") => {
+            let client_count = args.opt_free_from_str()?.unwrap_or(2);
+            let depth = args.opt_free_from_str()?.unwrap_or(8);
+            build_checker(client_count)
+                .target_max_depth(depth)
+                .spawn_dfs()
+                .join_and_report(&mut WriteReporter::new(&mut std::io::stdout()));
+        }
+        Some("explore") => {
+            let client_count = args.opt_free_from_str()?.unwrap_or(2);
+            let address = args
+                .opt_free_from_str()?
+                .unwrap_or("localhost:3000".to_string());
+            println!(
+                "Exploring state space for last-writer-wins register with {} clients on {}.",
+                client_count, address
+            );
+            build_checker(client_count).serve(address);
+        }
+        Some("spawn") => {
+            let port = 3000;
+
+            println!("  A server that implements a last-writer-wins register.");
+            println!("  You can monitor and interact using tcpdump and netcat.");
+            println!("  Use `tcpdump -D` if you see error `lo0: No such device exists`.");
+            println!("Examples:");
+            println!("$ sudo tcpdump -i lo0 -s 0 -nnX");
+            println!("$ nc -u localhost {}", port);
+            println!();
+            println!("  This will run indefinitely to explore the state space.");
+            println!();
+
+            let id0 = Id::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+            let id1 = Id::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port + 1));
+            let id2 = Id::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port + 2));
+            spawn(
+                serde_json::to_vec,
+                |bytes| serde_json::from_slice(bytes),
+                vec![
+                    (
+                        id0,
+                        LwwActor {
+                            peers: vec![id1, id2],
+                        },
+                    ),
+                    (
+                        id1,
+                        LwwActor {
+                            peers: vec![id0, id2],
+                        },
+                    ),
+                    (
+                        id2,
+                        LwwActor {
+                            peers: vec![id0, id1],
+                        },
+                    ),
+                ],
+            )
+            .unwrap();
+        }
+        _ => {
+            println!("USAGE:");
+            println!("  ./lww-register check [CLIENT_COUNT] [DEPTH]");
+            println!("  ./lww-register explore [CLIENT_COUNT] [ADDRESS]");
+            println!("  ./lww-register spawn");
+        }
+    }
+    Ok(())
+}

--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -112,6 +112,7 @@ impl Actor for PaxosActor {
     type Msg = RegisterMsg<RequestId, Value, PaxosMsg>;
     type State = PaxosState;
     type Timer = ();
+    type Random = ();
 
     fn name(&self) -> String {
         "Paxos Server".to_owned()

--- a/examples/single-copy-register.rs
+++ b/examples/single-copy-register.rs
@@ -19,6 +19,7 @@ impl Actor for SingleCopyActor {
     type Msg = RegisterMsg<RequestId, Value, ()>;
     type State = Value;
     type Timer = ();
+    type Random = ();
 
     fn on_start(&self, _id: Id, _o: &mut Out<Self>) -> Self::State {
         Value::default()

--- a/examples/timers.rs
+++ b/examples/timers.rs
@@ -33,6 +33,7 @@ impl Actor for PingerActor {
     type Msg = PingerMsg;
     type State = PingerState;
     type Timer = PingerTimer;
+    type Random = ();
 
     fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
         o.set_timer(PingerTimer::Even, model_timeout());

--- a/src/actor/actor_test_util.rs
+++ b/src/actor/actor_test_util.rs
@@ -19,6 +19,7 @@ pub mod ping_pong {
         type Msg = PingPongMsg;
         type State = u32; // count
         type Timer = ();
+        type Random = ();
 
         fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
             if let Some(id) = self.serve_to {

--- a/src/actor/ordered_reliable_link.rs
+++ b/src/actor/ordered_reliable_link.rs
@@ -82,6 +82,7 @@ where
     type Msg = MsgWrapper<A::Msg>;
     type State = StateWrapper<A::Msg, A::State>;
     type Timer = TimerWrapper<A::Timer>;
+    type Random = A::Random;
 
     fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {
         o.set_timer(TimerWrapper::Network, self.resend_interval.clone());
@@ -204,6 +205,9 @@ fn process_output<A: Actor>(
                     .insert(state.next_send_seq, (dst, inner_msg));
                 state.next_send_seq += 1;
             }
+            Command::ChooseRandom(_, _) => {
+                todo!("ChooseRandom is not supported at this time");
+            }
         }
     }
 }
@@ -229,6 +233,7 @@ mod test {
         type Msg = TestMsg;
         type State = Received;
         type Timer = ();
+        type Random = ();
 
         fn on_start(&self, _id: Id, o: &mut Out<Self>) -> Self::State {
             if let TestActor::Sender { receiver_id } = self {

--- a/src/actor/register.rs
+++ b/src/actor/register.rs
@@ -126,6 +126,7 @@ where
     type Msg = RegisterMsg<u64, char, InternalMsg>;
     type State = RegisterActorState<ServerActor::State, u64>;
     type Timer = ServerActor::Timer;
+    type Random = ServerActor::Random;
 
     fn name(&self) -> String {
         match self {

--- a/src/actor/write_once_register.rs
+++ b/src/actor/write_once_register.rs
@@ -132,6 +132,7 @@ where
     type Msg = WORegisterMsg<u64, char, InternalMsg>;
     type State = WORegisterActorState<ServerActor::State, u64>;
     type Timer = ServerActor::Timer;
+    type Random = ServerActor::Random;
 
     #[allow(clippy::identity_op)]
     fn on_start(&self, id: Id, o: &mut Out<Self>) -> Self::State {

--- a/src/checker/explorer.rs
+++ b/src/checker/explorer.rs
@@ -322,7 +322,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::actor::Timers;
+    use crate::actor::{RandomChoices, Timers};
     use crate::test_util::binary_clock::*;
     use lazy_static::lazy_static;
 
@@ -426,6 +426,7 @@ mod test {
                         actor_states: vec![Arc::new(0), Arc::new(0)],
                         history: (0, 1),
                         timers_set: vec![Timers::new(); 2],
+                        random_choices: vec![RandomChoices::default(); 2],
                         crashed: vec![false; 2],
                         network: Network::new_unordered_nonduplicating([
                             Envelope { src: Id::from(0), dst: Id::from(1), msg: Ping(0) },
@@ -450,6 +451,7 @@ mod test {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
                     timers_set: vec![Timers::new(); 2],
+                    random_choices: vec![RandomChoices::default(); 2],
                     crashed: vec![false; 2],
                     network: Network::new_unordered_nonduplicating([Envelope {
                         src: Id::from(0),
@@ -471,6 +473,7 @@ mod test {
                     actor_states: vec![Arc::new(0), Arc::new(0)],
                     history: (0, 1),
                     timers_set: vec![Timers::new(); 2],
+                    random_choices: vec![RandomChoices::default(); 2],
                     crashed: vec![false; 2],
                     network: Network::new_unordered_nonduplicating([]),
                 }),
@@ -496,6 +499,7 @@ mod test {
                     ],
                     history: (1, 2),
                     timers_set: vec![Timers::new(); 2],
+                    random_choices: vec![RandomChoices::default(); 2],
                     crashed: vec![false; 2],
                     network: Network::new_unordered_nonduplicating([
                         Envelope { src: Id::from(1), dst: Id::from(0), msg: Pong(0) },


### PR DESCRIPTION
(As discussed on https://github.com/stateright/stateright/discussions/79)

The `actor::Out::choose_random` method gives a way to model
non-deterministic choices by an Actor. It supplies a vec of choices with
type `Actor::Random`, which `ActorModelState` will then pick one. A string
key is also provided with the choose_random method, which can be used
to overwrite or remove previously registered random choices.

For explorer and DFS / BFS simulations, these random choices are modeled
as part of `ActorModel::actions`. For `actor::spawn`, the random choice is
is modeled as a timer with a duration between 0 - 10 seconds.

Because of the additions of the generic associated type Random and the
type parameters, this is a major semver change. Existing users of the
actor framework will need to add `type Random = ()`.

Because of the addition of string keys for random actions,
`ActorModelAction` also no longer implements `Copy`.