### PR TITLE
Fix bugs in `model_state.rs`

### DIFF
--- a/examples/increment.rs
+++ b/examples/increment.rs
@@ -33,7 +33,7 @@
 //! In the rest of this explanation, to match the implementation we use `i` to represent `SHARED`,
 //! `ts[_]` to represent each `thread_local`, and `pcs[_]` to represent each program counter.
 //!
-//! Without symmetry reduction, the state space is comprised of 13 unique states:
+//! Without symmetry reduction, the state space is composed of 13 unique states:
 //!
 //! ```
 //! // 1. The system has a deterministic initial state.

--- a/examples/paxos.rs
+++ b/examples/paxos.rs
@@ -3,7 +3,7 @@
 //!
 //! # The Algorithm
 //!
-//! The Paxos algorithm is comprised of two phases. These are best understood in reverse order.
+//! The Paxos algorithm is composed of two phases. These are best understood in reverse order.
 //!
 //! ## Phase 2
 //!

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -786,7 +786,7 @@ mod test {
                     actor_states: states.into_iter().map(Arc::new).collect::<Vec<_>>(),
                     network: Network::new_unordered_duplicating_with_last_msg(envelopes, last_msg),
                     timers_set,
-                    random_choices: vec![],
+                    random_choices: vec![RandomChoices::default(); 2],
                     crashed,
                     history: (0_u32, 0_u32), // constant as `maintains_history: false`
                 }

--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -50,7 +50,7 @@ pub enum ActorModelAction<Msg, Timer, Random> {
     },
     /// A message can be dropped if the network is lossy.
     Drop(Envelope<Msg>),
-    /// An actor can by notified after a timeout.
+    /// An actor can be notified after a timeout.
     Timeout(Id, Timer),
     Crash(Id),
     /// A random selection by a node.
@@ -328,7 +328,7 @@ where
                 let index = usize::from(id);
                 let last_actor_state = &last_sys_state.actor_states.get(index);
 
-                // Not all messags can be delivered, so ignore those.
+                // Not all messages can be delivered, so ignore those.
                 if last_actor_state.is_none() {
                     return None;
                 }
@@ -1244,7 +1244,7 @@ mod test {
         // Unordered duplicating networks can deliver/drop duplicates.
         //
         // IMPORTANT: in the context of a duplicating network, "dropping" must either entail:
-        //            (1) a no-op or (2) never deliving again. This implementation favors the
+        //            (1) a no-op or (2) never delivering again. This implementation favors the
         //            latter.
         let unord_dup_lossless =
             enumerate_action_sequences(LossyNetwork::No, Network::new_unordered_duplicating([]));
@@ -1368,7 +1368,7 @@ mod test {
     }
 
     #[test]
-    fn overwite_choose_random() {
+    fn overwrite_choose_random() {
         #[derive(Hash, PartialEq, Eq, Debug, Clone)]
         enum TestRandom {
             Choice1,

--- a/src/actor/model_state.rs
+++ b/src/actor/model_state.rs
@@ -22,7 +22,7 @@ pub struct ActorModelState<A: Actor, H = ()> {
 }
 
 /// Represents a set of random choices for one actor.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash, Eq, PartialEq)]
 pub struct RandomChoices<Random> {
     /// The map of random choices for an actor.
     ///
@@ -72,11 +72,12 @@ where
 {
     fn serialize<Ser: serde::Serializer>(&self, ser: Ser) -> Result<Ser::Ok, Ser::Error> {
         use serde::ser::SerializeStruct;
-        let mut out = ser.serialize_struct("ActorModelState", 4)?;
+        let mut out = ser.serialize_struct("ActorModelState", 6)?;
         out.serialize_field("actor_states", &self.actor_states)?;
         out.serialize_field("network", &self.network)?;
-        out.serialize_field("is_timer_set", &self.timers_set)?;
+        out.serialize_field("timers_set", &self.timers_set)?;
         out.serialize_field("random_choices", &self.random_choices)?;
+        out.serialize_field("crashed", &self.crashed)?;
         out.serialize_field("history", &self.history)?;
         out.end()
     }
@@ -112,8 +113,9 @@ where
         let mut builder = f.debug_struct("ActorModelState");
         builder.field("actor_states", &self.actor_states);
         builder.field("history", &self.history);
-        builder.field("is_timer_set", &self.timers_set);
+        builder.field("timers_set", &self.timers_set);
         builder.field("random_choices", &self.random_choices);
+        builder.field("crashed", &self.crashed);
         builder.field("network", &self.network);
         builder.finish()
     }
@@ -141,6 +143,8 @@ where
         self.history.hash(state);
         self.timers_set.hash(state);
         self.network.hash(state);
+        self.random_choices.hash(state);
+        self.crashed.hash(state);
     }
 }
 
@@ -157,6 +161,8 @@ where
             && self.history.eq(&other.history)
             && self.timers_set.eq(&other.timers_set)
             && self.network.eq(&other.network)
+            && self.random_choices.eq(&other.random_choices)
+            && self.crashed.eq(&other.crashed)
     }
 }
 

--- a/src/actor/register.rs
+++ b/src/actor/register.rs
@@ -92,7 +92,7 @@ impl<RequestId, Value, InternalMsg> RegisterMsg<RequestId, Value, InternalMsg> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RegisterActor<ServerActor> {
-    /// A client that [`RegisterMsg::Put`]s a message and upon receving a
+    /// A client that [`RegisterMsg::Put`]s a message and upon receiving a
     /// corresponding [`RegisterMsg::PutOk`] follows up with a
     /// [`RegisterMsg::Get`].
     Client {

--- a/src/actor/write_once_register.rs
+++ b/src/actor/write_once_register.rs
@@ -98,7 +98,7 @@ impl<RequestId, Value, InternalMsg> WORegisterMsg<RequestId, Value, InternalMsg>
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WORegisterActor<ServerActor> {
-    /// A client that [`WORegisterMsg::Put`]s a message and upon receving a
+    /// A client that [`WORegisterMsg::Put`]s a message and upon receiving a
     /// corresponding [`WORegisterMsg::PutOk`] follows up with a
     /// [`WORegisterMsg::Get`].
     Client {

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -152,7 +152,7 @@ impl<M: Model> CheckerBuilder<M> {
 
     /// Spawns a breadth-first search model checker. This traversal strategy uses more memory than
     /// [`CheckerBuilder::spawn_dfs`] but will find the shortest [`Path`] to each discovery if
-    /// checking is single threadeded (the default behavior, which [`CheckerBuilder::threads`]
+    /// checking is single threaded (the default behavior, which [`CheckerBuilder::threads`]
     /// overrides).
     ///
     /// This call does not block the current thread. Call [`Checker::join`] to block until checking

--- a/src/checker/bfs.rs
+++ b/src/checker/bfs.rs
@@ -264,7 +264,7 @@ where
                         ..
                     } => {
                         // The checker early exits after finding discoveries for every property,
-                        // and "eventually" property discoveries are only identifid at terminal
+                        // and "eventually" property discoveries are only identified at terminal
                         // states, so if we are here it means we are still awaiting a corresponding
                         // discovery regardless of whether the eventually property is now satisfied
                         // (i.e. it might be falsifiable via a different path).

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -268,7 +268,7 @@ where
                         ..
                     } => {
                         // The checker early exits after finding discoveries for every property,
-                        // and "eventually" property discoveries are only identifid at terminal
+                        // and "eventually" property discoveries are only identified at terminal
                         // states, so if we are here it means we are still awaiting a corresponding
                         // discovery regardless of whether the eventually property is now satisfied
                         // (i.e. it might be falsifiable via a different path).

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -318,7 +318,7 @@ where
                         ..
                     } => {
                         // The checker early exits after finding discoveries for every property,
-                        // and "eventually" property discoveries are only identifid at terminal
+                        // and "eventually" property discoveries are only identified at terminal
                         // states, so if we are here it means we are still awaiting a corresponding
                         // discovery regardless of whether the eventually property is now satisfied
                         // (i.e. it might be falsifiable via a different path).

--- a/src/checker/simulation.rs
+++ b/src/checker/simulation.rs
@@ -339,7 +339,7 @@ where
                         ..
                     } => {
                         // The checker early exits after finding discoveries for every property,
-                        // and "eventually" property discoveries are only identifid at terminal
+                        // and "eventually" property discoveries are only identified at terminal
                         // states, so if we are here it means we are still awaiting a corresponding
                         // discovery regardless of whether the eventually property is now satisfied
                         // (i.e. it might be falsifiable via a different path).

--- a/src/job_market.rs
+++ b/src/job_market.rs
@@ -109,7 +109,7 @@ impl<Job> JobBroker<Job> {
                 market.open_count = market.open_count.saturating_sub(1);
                 if market.open_count == 0 {
                     // we are the last running thread, notify all others and return so we can
-                    // shutdown properly
+                    // shut down properly
                     log::trace!(
                         "{}: No jobs. Last running thread.",
                         std::thread::current().name().unwrap_or_default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ pub trait Model: Sized {
     }
 }
 
-/// A named predicate, such as "an epoch *sometimes* has no leader" (for which the the model
+/// A named predicate, such as "an epoch *sometimes* has no leader" (for which the model
 /// checker would find an example) or "an epoch *always* has at most one leader" (for which the
 /// model checker would find a counterexample) or "a proposal is *eventually* accepted" (for
 /// which the model checker would find a counterexample path leading from the initial state
@@ -287,7 +287,7 @@ impl<M: Model> Property<M> {
     /// paths (those that end in either states with no successors or checking boundaries). A path
     /// ending in a cycle is not viewed as _terminating_ in that cycle, as the checker does not
     /// differentiate cycles from DAG joins, and so an `eventually` property that has not been met
-    /// by the cycle-closing edge will ignored -- a false negative.
+    /// by the cycle-closing edge will be ignored -- a false negative.
     pub fn eventually(name: &'static str, condition: fn(&M, &M::State) -> bool) -> Property<M> {
         Property {
             expectation: Expectation::Eventually,

--- a/src/util/vector_clock.rs
+++ b/src/util/vector_clock.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Display, Formatter};
 use std::hash::{Hash, Hasher};
 
 /// A [vector clock](https://en.wikipedia.org/wiki/Vector_clock), which provides a partial causal
-/// order on events in a distributed sytem.
+/// order on events in a distributed system.
 #[derive(Clone, Debug, Default, Eq, serde::Serialize, serde::Deserialize)]
 pub struct VectorClock(Vec<u32>);
 


### PR DESCRIPTION
I made some modifications:
Fixed some typos in code comments.

And in `model_state.rs`:
1. Modified the `serialize` function.
2. Based on the same logic, also modified the `fmt` function.
3. In the `Hash` and `Eq` implementations, I noticed that both were missing handling for the `crashed` and `random_choices` fields. Based on my understanding, both of these fields should be considered when comparing `ActorModelState` instances for equality. So I added handling for them. Additionally, in order to use the `hash` and `eq` methods for the `random_choices` field, I derived `Hash`, `Eq`, and `PartialEq` for the `RandomChoices` struct.

Also, in `visits_expected_states` in `model.rs`, I change the initialization of `random_choices` to pass the test after the 3rd change above.
