### PR TITLE
Eventually fix

### DIFF
--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -1114,7 +1114,7 @@ mod test {
                 .unwrap()
                 .last_state()
                 .actor_states,
-            vec![Arc::new(4), Arc::new(5)]
+            vec![Arc::new(5), Arc::new(5)]
         );
     }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -678,6 +678,19 @@ mod test_eventually_property_checker {
             None
         ); // FIXME: `unwrap().into_states()` should be [0, 2, 4, 6]
     }
+    #[test]
+    fn cannot_overwrite_discovery_when_having_other_properties() {
+      assert_eq!(
+        DGraph::with_properties(vec![eventually_odd(), Property::always("ge_0", |_, s| *s >= 10)])
+            .with_path(vec![ 12, 14])
+            .with_path(vec![ 12, 15]) 
+            .check()
+            .discovery("odd")
+            .unwrap()
+            .into_states(),
+        vec![12, 14]
+      )
+    }
 }
 
 #[cfg(test)]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -655,7 +655,7 @@ mod test_eventually_property_checker {
                 .discovery("odd")
                 .unwrap()
                 .into_states(),
-            vec![2, 4, 6]
+            vec![2, 4, 8]
         );
     }
 

--- a/src/checker/bfs.rs
+++ b/src/checker/bfs.rs
@@ -231,7 +231,9 @@ where
             let mut is_awaiting_discoveries = false;
             for (i, property) in properties.iter().enumerate() {
                 if discoveries.contains_key(property.name) {
-                    continue;
+                    if (property.expectation == Expectation::Eventually) && !ebits.contains(i) {
+                        continue;
+                    }
                 }
                 match property {
                     Property {

--- a/src/checker/dfs.rs
+++ b/src/checker/dfs.rs
@@ -235,7 +235,9 @@ where
             let mut is_awaiting_discoveries = false;
             for (i, property) in properties.iter().enumerate() {
                 if discoveries.contains_key(property.name) {
-                    continue;
+                    if (property.expectation == Expectation::Eventually) && !ebits.contains(i) {
+                        continue;
+                    }
                 }
                 match property {
                     Property {

--- a/src/checker/on_demand.rs
+++ b/src/checker/on_demand.rs
@@ -285,7 +285,9 @@ where
             let mut is_awaiting_discoveries = false;
             for (i, property) in properties.iter().enumerate() {
                 if discoveries.contains_key(property.name) {
-                    continue;
+                    if (property.expectation == Expectation::Eventually) && !ebits.contains(i) {
+                        continue;
+                    }
                 }
                 match property {
                     Property {

--- a/src/checker/simulation.rs
+++ b/src/checker/simulation.rs
@@ -306,7 +306,9 @@ where
             let mut is_awaiting_discoveries = false;
             for (i, property) in properties.iter().enumerate() {
                 if discoveries.contains_key(property.name) {
-                    continue;
+                    if (property.expectation == Expectation::Eventually) && !ebits.contains(i) {
+                        continue;
+                    }
                 }
                 match property {
                     Property {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -56,16 +56,20 @@ pub mod dgraph {
     pub struct DGraph {
         inits: BTreeSet<u8>,
         edges: BTreeMap<u8, BTreeSet<u8>>,
-        property: Property<DGraph>,
+        property: Vec<Property<DGraph>>,
     }
 
     impl DGraph {
-        pub fn with_property(property: Property<DGraph>) -> Self {
+        pub fn with_properties(properties: Vec<Property<DGraph>>) -> Self {
             DGraph {
                 inits: Default::default(),
                 edges: Default::default(),
-                property,
+                property: properties,
             }
+        }
+
+        pub fn with_property(property: Property<DGraph>) -> Self {
+            Self::with_properties(vec![property])
         }
 
         pub fn with_path(mut self, path: Vec<u8>) -> Self {
@@ -110,7 +114,7 @@ pub mod dgraph {
         }
 
         fn properties(&self) -> Vec<Property<Self>> {
-            vec![self.property.clone()]
+            self.property.clone()
         }
     }
 }


### PR DESCRIPTION
Assuming that an eventually counter-example is found, then the next terminal state where there are still discoveries to find, will have the ebits set and hence not early exist and thus overwrite the eventually counterexample.

This PR stops the above behaviour.
There is one commit which adds the test, and one commit with the corresponding fix for all checkers.

There are also other tests which seem to be failing, but that is the same as on the main branch.