### PR TITLE
Panic on property name collision

### DIFF
--- a/src/actor/model.rs
+++ b/src/actor/model.rs
@@ -150,6 +150,8 @@ where
         name: &'static str,
         condition: fn(&ActorModel<A, C, H>, &ActorModelState<A, H>) -> bool,
     ) -> Self {
+        assert!(!self.properties.iter().any(|p| p.name == name),
+            "Property with name '{}' already exists", name);
         self.properties.push(Property {
             expectation,
             name,


### PR DESCRIPTION
If there are multiple properties with the same name, for example a `Sometimes` and a `Eventually` property, then the `Sometimes` discovery may be misattributed to an `Eventually` counterexample.

This prevents that by enforcing that all property names are unique.